### PR TITLE
Async Everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,53 @@
 [![minzipped](https://img.shields.io/bundlephobia/minzip/squirreling)](https://www.npmjs.com/package/squirreling)
 [![workflow status](https://github.com/hyparam/squirreling/actions/workflows/ci.yml/badge.svg)](https://github.com/hyparam/squirreling/actions)
 [![mit license](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT)
-![coverage](https://img.shields.io/badge/Coverage-89-darkred)
+![coverage](https://img.shields.io/badge/Coverage-90-darkred)
 [![dependencies](https://img.shields.io/badge/Dependencies-0-blueviolet)](https://www.npmjs.com/package/squirreling?activeTab=dependencies)
 
-Squirreling is a lightweight SQL engine for JavaScript applications, designed to provide efficient and easy-to-use database functionalities in the browser.
+Squirreling is a streaming async SQL engine for JavaScript. It is designed to provide efficient streaming of results from pluggable backend for highly efficient retrieval of data for browser applications.
 
 ## Features
 
 - Lightweight and fast
-- Easy to integrate with JavaScript applications
+- Easy to integrate with frontend applications
+- Lets you move query execution closer to your users
 - Supports standard SQL queries
-- In-memory database for quick data access
-- Robust error handling and validation
+- Async streaming for large datasets
+- Constant memory usage for simple queries with LIMIT
+- Robust error handling and validation designed for LLM tool use
+- In-memory data option for simple use cases
 
 ## Usage
+
+Squirreling returns an async generator, allowing you to process rows one at a time without loading everything into memory.
 
 ```javascript
 import { executeSql } from 'squirreling'
 
+// In-memory table
 const users = [
-  { id: 1, name: 'Alice' },
-  { id: 2, name: 'Bob' },
+  { id: 1, name: 'Alice', active: true },
+  { id: 2, name: 'Bob', active: false },
+  { id: 3, name: 'Charlie', active: true },
+  // ...more rows
 ]
 
-const result = executeSql({
+// Process rows as they arrive (streaming)
+for await (const user of executeSql({
   tables: { users },
-  query: 'SELECT UPPER(name) AS name_upper FROM users',
-})
-console.log(result)
-// Output: [ { name_upper: 'ALICE' }, { name_upper: 'BOB' } ]
+  query: 'SELECT * FROM users WHERE active = TRUE LIMIT 100',
+})) {
+  console.log(user.name)
+}
+```
+
+There is an exported helper function `collect` to gather all rows into an array if needed:
+
+```javascript
+import { collect } from 'squirreling'
+const allUsers = await collect(executeSql({
+  tables: { users },
+  query: 'SELECT * FROM users',
+}))
+console.log(allUsers)
 ```

--- a/src/backend/memory.js
+++ b/src/backend/memory.js
@@ -1,5 +1,5 @@
 /**
- * @import { DataSource, RowSource } from '../types.js'
+ * @import { AsyncDataSource, RowSource } from '../types.js'
  */
 
 /**
@@ -20,18 +20,17 @@ export function createRowAccessor(obj) {
 }
 
 /**
- * Creates a memory-backed data source from an array of plain objects
+ * Creates an async memory-backed data source from an array of plain objects
  *
  * @param {Record<string, any>[]} data - array of plain objects
- * @returns {DataSource} a data source interface
+ * @returns {AsyncDataSource} an async data source interface
  */
-export function createMemorySource(data) {
+export function createAsyncMemorySource(data) {
   return {
-    getNumRows() {
-      return data.length
-    },
-    getRow(index) {
-      return createRowAccessor(data[index])
+    async *getRows() {
+      for (const item of data) {
+        yield createRowAccessor(item)
+      }
     },
   }
 }

--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -6,16 +6,16 @@ import { evaluateExpr } from './expression.js'
  * @import { AggregateColumn, ExprNode, RowSource } from '../types.js'
  * @param {AggregateColumn} col - aggregate column definition
  * @param {RowSource[]} rows - rows to aggregate
- * @returns {number | null} aggregated result
+ * @returns {Promise<number | null>} aggregated result
  */
-export function evaluateAggregate(col, rows) {
+export async function evaluateAggregate(col, rows) {
   const { arg, func } = col
 
   if (func === 'COUNT') {
     if (arg.kind === 'star') return rows.length
     let count = 0
     for (let i = 0; i < rows.length; i += 1) {
-      const v = evaluateExpr({ node: arg.expr, row: rows[i] })
+      const v = await evaluateExpr({ node: arg.expr, row: rows[i] })
       if (v !== null && v !== undefined) {
         count += 1
       }
@@ -35,7 +35,7 @@ export function evaluateAggregate(col, rows) {
     let max = null
 
     for (let i = 0; i < rows.length; i += 1) {
-      const raw = evaluateExpr({ node: arg.expr, row: rows[i] })
+      const raw = await evaluateExpr({ node: arg.expr, row: rows[i] })
       if (raw == null) continue
       const num = Number(raw)
       if (!Number.isFinite(num)) continue

--- a/src/execute/utils.js
+++ b/src/execute/utils.js
@@ -1,0 +1,14 @@
+/**
+ * Collects all results from an async generator into an array
+ *
+ * @template T
+ * @param {AsyncGenerator<T>} asyncGen - the async generator
+ * @returns {Promise<T[]>} array of all yielded values
+ */
+export async function collect(asyncGen) {
+  const results = []
+  for await (const item of asyncGen) {
+    results.push(item)
+  }
+  return results
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,11 +4,11 @@ import type { ExecuteSqlOptions, SelectStatement } from './types.js'
  * Executes a SQL SELECT query against an array of data rows
  *
  * @param options
- * @param options.tables - source data as a list of objects or a DataSource
+ * @param options.tables - source data as a list of objects or an AsyncDataSource
  * @param options.query - SQL query string
- * @returns rows matching the query
+ * @returns async generator yielding rows matching the query
  */
-export function executeSql(options: ExecuteSqlOptions): Record<string, any>[]
+export function executeSql(options: ExecuteSqlOptions): AsyncGenerator<Record<string, any>>
 
 /**
  * Parses a SQL query string into an abstract syntax tree
@@ -17,3 +17,11 @@ export function executeSql(options: ExecuteSqlOptions): Record<string, any>[]
  * @returns parsed SQL select statement
  */
 export function parseSql(query: string): SelectStatement
+
+/**
+ * Collects all results from an async generator into an array
+ *
+ * @param asyncGen - the async generator
+ * @returns array of all yielded values
+ */
+export function collect<T>(asyncGen: AsyncGenerator<T>): Promise<T[]>

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { executeSql } from './execute/execute.js'
 export { parseSql } from './parse/parse.js'
+export { collect } from './execute/utils.js'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,27 +1,24 @@
+
+/**
+ * Async data source for streaming SQL execution.
+ * Provides an async iterator over rows.
+ */
+export interface AsyncDataSource {
+  getRows(): AsyncIterable<RowSource>
+}
 export interface RowSource {
   getCell(name: string): any
   getKeys(): string[]
 }
 
-export interface DataSource {
-  getNumRows(): number
-  getRow(index: number): RowSource
-}
-
 export type RawData = Record<string, any>[]
 
 export interface ExecuteSqlOptions {
-  tables: Record<string, RawData | DataSource>
+  tables: Record<string, RawData | AsyncDataSource>
   query: string
 }
 
 export type SqlPrimitive = string | number | bigint | boolean | null
-
-export interface FromSubquery {
-  kind: 'subquery'
-  query: SelectStatement
-  alias: string
-}
 
 export interface SelectStatement {
   distinct: boolean
@@ -34,6 +31,12 @@ export interface SelectStatement {
   orderBy: OrderByItem[]
   limit?: number
   offset?: number
+}
+
+export interface FromSubquery {
+  kind: 'subquery'
+  query: SelectStatement
+  alias: string
 }
 
 export type BinaryOp =

--- a/test/execute/execute.between.test.js
+++ b/test/execute/execute.between.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('executeSql - BETWEEN', () => {
   const users = [
@@ -11,178 +11,178 @@ describe('executeSql - BETWEEN', () => {
   ]
 
   describe('basic BETWEEN queries', () => {
-    it('should filter with BETWEEN using numbers', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 28 AND 32' })
+    it('should filter with BETWEEN using numbers', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 28 AND 32' }))
       expect(result).toHaveLength(3)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Diana', 'Eve'])
     })
 
-    it('should include boundary values', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 30' })
+    it('should include boundary values', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 30' }))
       expect(result).toHaveLength(4)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Bob', 'Diana', 'Eve'])
     })
 
-    it('should filter with NOT BETWEEN', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age NOT BETWEEN 28 AND 32' })
+    it('should filter with NOT BETWEEN', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age NOT BETWEEN 28 AND 32' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Charlie'])
     })
 
-    it('should handle BETWEEN with equal bounds', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 30 AND 30' })
+    it('should handle BETWEEN with equal bounds', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 30 AND 30' }))
       expect(result).toHaveLength(2)
       expect(result.every(r => r.age === 30)).toBe(true)
     })
   })
 
   describe('BETWEEN with strings', () => {
-    it('should filter with BETWEEN using strings', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name BETWEEN \'B\' AND \'D\'' })
+    it('should filter with BETWEEN using strings', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name BETWEEN \'B\' AND \'D\'' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Charlie'])
     })
 
-    it('should handle string boundaries correctly', () => {
+    it('should handle string boundaries correctly', async () => {
       const data = [
         { id: 1, name: 'Alice' },
         { id: 2, name: 'Bob' },
         { id: 3, name: 'Charlie' },
         { id: 4, name: 'Diana' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE name BETWEEN \'Alice\' AND \'Charlie\'' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE name BETWEEN \'Alice\' AND \'Charlie\'' }))
       expect(result).toHaveLength(3)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Bob', 'Charlie'])
     })
   })
 
   describe('BETWEEN in complex expressions', () => {
-    it('should filter with BETWEEN and AND', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 30 AND city = \'NYC\'' })
+    it('should filter with BETWEEN and AND', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 30 AND city = \'NYC\'' }))
       expect(result).toHaveLength(2)
       expect(result.every(r => r.city === 'NYC' && r.age >= 25 && r.age <= 30)).toBe(true)
     })
 
-    it('should filter with BETWEEN and OR', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 28 OR age = 35' })
+    it('should filter with BETWEEN and OR', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 28 OR age = 35' }))
       expect(result).toHaveLength(3)
       expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Charlie', 'Diana'])
     })
 
-    it('should handle multiple BETWEEN clauses', () => {
+    it('should handle multiple BETWEEN clauses', async () => {
       const data = [
         { id: 1, age: 25, score: 80 },
         { id: 2, age: 30, score: 90 },
         { id: 3, age: 35, score: 70 },
         { id: 4, age: 28, score: 85 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE age BETWEEN 25 AND 30 AND score BETWEEN 80 AND 90' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE age BETWEEN 25 AND 30 AND score BETWEEN 80 AND 90' }))
       expect(result).toHaveLength(3)
       expect(result.map(r => r.id).sort()).toEqual([1, 2, 4])
     })
 
-    it('should handle BETWEEN with NOT', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE NOT (age BETWEEN 28 AND 32)' })
+    it('should handle BETWEEN with NOT', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE NOT (age BETWEEN 28 AND 32)' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Charlie'])
     })
   })
 
   describe('edge cases', () => {
-    it('should handle BETWEEN with null values', () => {
+    it('should handle BETWEEN with null values', async () => {
       const data = [
         { id: 1, value: 5 },
         { id: 2, value: 10 },
         { id: 3, value: null },
         { id: 4, value: 15 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value BETWEEN 8 AND 12' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value BETWEEN 8 AND 12' }))
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe(2)
     })
 
-    it('should handle BETWEEN with undefined values', () => {
+    it('should handle BETWEEN with undefined values', async () => {
       const data = [
         { id: 1, value: 5 },
         { id: 2, value: 10 },
         { id: 3 },
         { id: 4, value: 15 },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { data },
         query: 'SELECT * FROM data WHERE value BETWEEN 8 AND 12',
-      })
+      }))
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe(2)
     })
 
-    it('should handle BETWEEN with inverted bounds', () => {
+    it('should handle BETWEEN with inverted bounds', async () => {
       // BETWEEN with lower > upper should return no results
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE age BETWEEN 35 AND 25',
-      })
+      }))
       expect(result).toHaveLength(0)
     })
 
-    it('should handle BETWEEN with negative numbers', () => {
+    it('should handle BETWEEN with negative numbers', async () => {
       const data = [
         { id: 1, value: -10 },
         { id: 2, value: -5 },
         { id: 3, value: 0 },
         { id: 4, value: 5 },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { data },
         query: 'SELECT * FROM data WHERE value BETWEEN -8 AND 2',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.id).sort()).toEqual([2, 3])
     })
 
-    it('should handle BETWEEN with floats', () => {
+    it('should handle BETWEEN with floats', async () => {
       const data = [
         { id: 1, price: 9.99 },
         { id: 2, price: 15.50 },
         { id: 3, price: 20.00 },
         { id: 4, price: 25.99 },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { data },
         query: 'SELECT * FROM data WHERE price BETWEEN 10.00 AND 20.00',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.id).sort()).toEqual([2, 3])
     })
   })
 
   describe('BETWEEN with SELECT columns', () => {
-    it('should work with BETWEEN and column selection', () => {
-      const result = executeSql({
+    it('should work with BETWEEN and column selection', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT name, age FROM users WHERE age BETWEEN 28 AND 32',
-      })
+      }))
       expect(result).toHaveLength(3)
       expect(result[0]).toHaveProperty('name')
       expect(result[0]).toHaveProperty('age')
       expect(result[0]).not.toHaveProperty('city')
     })
 
-    it('should work with BETWEEN and ORDER BY', () => {
-      const result = executeSql({
+    it('should work with BETWEEN and ORDER BY', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 32 ORDER BY age ASC',
-      })
+      }))
       expect(result).toHaveLength(4)
       expect(result[0].age).toBe(25)
       expect(result[result.length - 1].age).toBe(30)
     })
 
-    it('should work with BETWEEN and LIMIT', () => {
-      const result = executeSql({
+    it('should work with BETWEEN and LIMIT', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE age BETWEEN 25 AND 35 ORDER BY age LIMIT 2',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result[0].age).toBe(25)
       expect(result[1].age).toBe(28)

--- a/test/execute/execute.group.test.js
+++ b/test/execute/execute.group.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('executeSql - GROUP BY', () => {
   const users = [
@@ -10,8 +10,8 @@ describe('executeSql - GROUP BY', () => {
     { id: 5, name: 'Eve', age: 30, city: 'NYC', active: true },
   ]
 
-  it('should group by single column', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) AS count FROM users GROUP BY city' })
+  it('should group by single column', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) AS count FROM users GROUP BY city' }))
     expect(result).toHaveLength(2)
     const nycGroup = result.find(r => r.city === 'NYC')
     const laGroup = result.find(r => r.city === 'LA')
@@ -19,48 +19,48 @@ describe('executeSql - GROUP BY', () => {
     expect(laGroup?.count).toBe(2)
   })
 
-  it('should group by multiple columns', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT city, age, COUNT(*) AS count FROM users GROUP BY city, age' })
+  it('should group by multiple columns', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, age, COUNT(*) AS count FROM users GROUP BY city, age' }))
     expect(result.length).toBeGreaterThan(2)
     const nycAge30 = result.find(r => r.city === 'NYC' && r.age === 30)
     expect(nycAge30?.count).toBe(2)
   })
 
-  it('should handle aggregates with GROUP BY', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT city, AVG(age) AS avg_age FROM users GROUP BY city' })
+  it('should handle aggregates with GROUP BY', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, AVG(age) AS avg_age FROM users GROUP BY city' }))
     expect(result).toHaveLength(2)
     const nycGroup = result.find(r => r.city === 'NYC')
     expect(nycGroup?.avg_age).toBeCloseTo(31.67, 1)
   })
 
-  it('should select non-grouped column (takes first value)', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT city, name, COUNT(*) AS count FROM users GROUP BY city' })
+  it('should select non-grouped column (takes first value)', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, name, COUNT(*) AS count FROM users GROUP BY city' }))
     expect(result).toHaveLength(2)
     expect(result.every(r => r.name)).toBe(true)
   })
 
-  it('should handle empty groups with SELECT *', () => {
+  it('should handle empty groups with SELECT *', async () => {
     const data = [
       { id: 1, city: 'NYC', age: 30 },
       { id: 2, city: 'LA', age: 25 },
     ]
     // Filter creates empty result, then GROUP BY
-    const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE age > 100 GROUP BY city' })
+    const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE age > 100 GROUP BY city' }))
     expect(result).toEqual([])
   })
 
-  it('should group by multiple columns with ORDER BY', () => {
-    const result = executeSql({ tables: { users }, query: `
+  it('should group by multiple columns with ORDER BY', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: `
       SELECT city, active, COUNT(*) AS count
       FROM users
       GROUP BY city, active
       ORDER BY city, active DESC
-    ` })
+    ` }))
     expect(result.length).toBeGreaterThan(0)
     expect(result.every(r => r.count > 0)).toBe(true)
   })
 
-  it('should aggregate with multiple group columns', () => {
+  it('should aggregate with multiple group columns', async () => {
     const sales = [
       { region: 'North', product: 'A', amount: 100 },
       { region: 'North', product: 'B', amount: 150 },
@@ -68,12 +68,12 @@ describe('executeSql - GROUP BY', () => {
       { region: 'South', product: 'B', amount: 120 },
       { region: 'North', product: 'A', amount: 80 },
     ]
-    const result = executeSql({ tables: { sales }, query: `
+    const result = await collect(executeSql({ tables: { sales }, query: `
       SELECT region, product, SUM(amount) AS total, COUNT(*) AS sales_count
       FROM sales
       GROUP BY region, product
       ORDER BY region, product
-    ` })
+    ` }))
     const northA = result.find(r => r.region === 'North' && r.product === 'A')
     expect(northA?.total).toBe(180)
     expect(northA?.sales_count).toBe(2)

--- a/test/execute/execute.having.test.js
+++ b/test/execute/execute.having.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('executeSql - HAVING clause', () => {
   const users = [
@@ -11,40 +11,40 @@ describe('executeSql - HAVING clause', () => {
     { id: 6, name: 'Frank', age: 22, city: 'Chicago', active: true },
   ]
 
-  it('should filter groups with HAVING COUNT(*)', () => {
-    const result = executeSql({
+  it('should filter groups with HAVING COUNT(*)', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users GROUP BY city HAVING COUNT(*) > 2',
-    })
+    }))
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({ city: 'NYC', cnt: 3 })
   })
 
-  it('should filter groups with HAVING on aggregate comparison', () => {
-    const result = executeSql({
+  it('should filter groups with HAVING on aggregate comparison', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, AVG(age) AS avg_age FROM users GROUP BY city HAVING AVG(age) > 28',
-    })
+    }))
     expect(result.length).toBeGreaterThan(0)
     for (const row of result) {
       expect(row.avg_age).toBeGreaterThan(28)
     }
   })
 
-  it('should filter groups with HAVING using column reference', () => {
-    const result = executeSql({
+  it('should filter groups with HAVING using column reference', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users GROUP BY city HAVING city = \'NYC\'',
-    })
+    }))
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({ city: 'NYC', cnt: 3 })
   })
 
-  it('should handle HAVING with multiple conditions using AND', () => {
-    const result = executeSql({
+  it('should handle HAVING with multiple conditions using AND', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt, AVG(age) AS avg_age FROM users GROUP BY city HAVING COUNT(*) >= 2 AND AVG(age) > 25',
-    })
+    }))
     expect(result.length).toBeGreaterThan(0)
     for (const row of result) {
       expect(row.cnt).toBeGreaterThanOrEqual(2)
@@ -52,56 +52,56 @@ describe('executeSql - HAVING clause', () => {
     }
   })
 
-  it('should handle HAVING with OR condition', () => {
-    const result = executeSql({
+  it('should handle HAVING with OR condition', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users GROUP BY city HAVING COUNT(*) > 2 OR city = \'Chicago\'',
-    })
+    }))
     expect(result.length).toBeGreaterThan(0)
     const cities = result.map(r => r.city)
     expect(cities).toContain('NYC')
     expect(cities).toContain('Chicago')
   })
 
-  it('should combine WHERE, GROUP BY, and HAVING', () => {
-    const result = executeSql({
+  it('should combine WHERE, GROUP BY, and HAVING', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users WHERE age > 25 GROUP BY city HAVING COUNT(*) >= 2',
-    })
+    }))
     expect(result.length).toBeGreaterThan(0)
     for (const row of result) {
       expect(row.cnt).toBeGreaterThanOrEqual(2)
     }
   })
 
-  it('should handle HAVING with SUM aggregate', () => {
+  it('should handle HAVING with SUM aggregate', async () => {
     const sales = [
       { region: 'North', product: 'A', amount: 100 },
       { region: 'North', product: 'A', amount: 150 },
       { region: 'South', product: 'A', amount: 50 },
       { region: 'North', product: 'B', amount: 80 },
     ]
-    const result = executeSql({
+    const result = await collect(executeSql({
       tables: { sales },
       query: 'SELECT region, SUM(amount) AS total FROM sales GROUP BY region HAVING SUM(amount) > 200',
-    })
+    }))
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({ region: 'North', total: 330 })
   })
 
-  it('should handle HAVING with MIN and MAX', () => {
-    const result = executeSql({
+  it('should handle HAVING with MIN and MAX', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, MIN(age) AS min_age, MAX(age) AS max_age FROM users GROUP BY city HAVING MAX(age) > 30',
-    })
+    }))
     expect(result.length).toBeGreaterThan(0)
     for (const row of result) {
       expect(row.max_age).toBeGreaterThan(30)
     }
   })
 
-  it('should handle complex query with WHERE, GROUP BY, HAVING, ORDER BY, and LIMIT', () => {
-    const result = executeSql({
+  it('should handle complex query with WHERE, GROUP BY, HAVING, ORDER BY, and LIMIT', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: `SELECT city, COUNT(*) AS cnt, AVG(age) AS avg_age
        FROM users
@@ -110,7 +110,7 @@ describe('executeSql - HAVING clause', () => {
        HAVING COUNT(*) >= 2
        ORDER BY cnt DESC
        LIMIT 2`,
-    })
+    }))
     expect(result.length).toBeLessThanOrEqual(2)
     expect(result.length).toBeGreaterThan(0)
     for (const row of result) {
@@ -118,39 +118,39 @@ describe('executeSql - HAVING clause', () => {
     }
   })
 
-  it('should return empty result when no groups satisfy HAVING', () => {
-    const result = executeSql({
+  it('should return empty result when no groups satisfy HAVING', async () => {
+    const result = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users GROUP BY city HAVING COUNT(*) > 10',
-    })
+    }))
     expect(result).toEqual([])
   })
 
-  it('should handle HAVING with inequality operators', () => {
-    const result1 = executeSql({
+  it('should handle HAVING with inequality operators', async () => {
+    const result1 = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users GROUP BY city HAVING COUNT(*) <= 2',
-    })
+    }))
     expect(result1.length).toBeGreaterThan(0)
 
-    const result2 = executeSql({
+    const result2 = await collect(executeSql({
       tables: { users },
       query: 'SELECT city, COUNT(*) AS cnt FROM users GROUP BY city HAVING COUNT(*) != 3',
-    })
+    }))
     expect(result2.length).toBeGreaterThan(0)
   })
 
-  it('should handle HAVING with COUNT on specific column', () => {
+  it('should handle HAVING with COUNT on specific column', async () => {
     const data = [
       { city: 'NYC', name: 'Alice' },
       { city: 'NYC', name: 'Bob' },
       { city: 'NYC', name: null },
       { city: 'LA', name: 'Charlie' },
     ]
-    const result = executeSql({
+    const result = await collect(executeSql({
       tables: { data },
       query: 'SELECT city, COUNT(name) AS cnt FROM data GROUP BY city HAVING COUNT(name) >= 2',
-    })
+    }))
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({ city: 'NYC', cnt: 2 })
   })

--- a/test/execute/execute.orderby.test.js
+++ b/test/execute/execute.orderby.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('ORDER BY', () => {
   const users = [
@@ -10,43 +10,43 @@ describe('ORDER BY', () => {
     { id: 5, name: 'Eve', age: 30, city: 'NYC', active: true },
   ]
 
-  it('should sort ascending by default', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY age' })
+  it('should sort ascending by default', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY age' }))
     expect(result[0].age).toBe(25)
     expect(result[result.length - 1].age).toBe(35)
   })
 
-  it('should sort descending', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY age DESC' })
+  it('should sort descending', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY age DESC' }))
     expect(result[0].age).toBe(35)
     expect(result[result.length - 1].age).toBe(25)
   })
 
-  it('should sort by multiple columns', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY age ASC, name DESC' })
+  it('should sort by multiple columns', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY age ASC, name DESC' }))
     expect(result[0].name).toBe('Bob') // age 25
     const age30s = result.filter(r => r.age === 30)
     expect(age30s[0].name).toBe('Eve') // DESC order
   })
 
-  it('should handle null/undefined values in sorting', () => {
+  it('should handle null/undefined values in sorting', async () => {
     const data = [
       { id: 1, value: 10 },
       { id: 2, value: null },
       { id: 3, value: 5 },
     ]
-    const result = executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value' })
+    const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value' }))
     expect(result[0].value).toBe(null) // null comes first
     expect(result[1].value).toBe(5)
   })
 
-  it('should handle string sorting', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY name' })
+  it('should handle string sorting', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY name' }))
     expect(result[0].name).toBe('Alice')
     expect(result[result.length - 1].name).toBe('Eve')
   })
 
-  it('should handle CAST in ORDER BY clause', () => {
+  it('should handle CAST in ORDER BY clause', async () => {
     const data = [
       { path: '/file1.txt', size: '100' },
       { path: '/file2.txt', size: '50' },
@@ -54,7 +54,7 @@ describe('ORDER BY', () => {
       { path: '/file4.txt', size: '75' },
       { path: '/file5.txt', size: '150' },
     ]
-    const result = executeSql({ tables: { table: data }, query: 'SELECT path, size FROM table ORDER BY CAST(size AS INTEGER) DESC LIMIT 5' })
+    const result = await collect(executeSql({ tables: { table: data }, query: 'SELECT path, size FROM table ORDER BY CAST(size AS INTEGER) DESC LIMIT 5' }))
     expect(result).toHaveLength(5)
     expect(result[0].path).toBe('/file3.txt') // size 200
     expect(result[1].path).toBe('/file5.txt') // size 150
@@ -63,41 +63,41 @@ describe('ORDER BY', () => {
     expect(result[4].path).toBe('/file2.txt') // size 50
   })
 
-  it('should sort by column not included in SELECT', () => {
-    const result = executeSql({ tables: { users }, query: 'SELECT name FROM users ORDER BY age' })
+  it('should sort by column not included in SELECT', async () => {
+    const result = await collect(executeSql({ tables: { users }, query: 'SELECT name FROM users ORDER BY age' }))
     // Expected order by age: Bob (25), Diana (28), Alice (30), Eve (30), Charlie (35)
     expect(result.map(r => r.name)).toEqual(['Bob', 'Diana', 'Alice', 'Eve', 'Charlie'])
   })
 
   describe('ORDER BY with GROUP BY', () => {
-    it('should sort by GROUP BY column', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY city' })
+    it('should sort by GROUP BY column', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY city' }))
       expect(result[0].city).toBe('LA')
       expect(result[1].city).toBe('NYC')
     })
 
-    it('should sort by GROUP BY column DESC', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY city DESC' })
+    it('should sort by GROUP BY column DESC', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY city DESC' }))
       expect(result[0].city).toBe('NYC')
       expect(result[1].city).toBe('LA')
     })
 
-    it('should sort by aggregate alias', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY cnt DESC' })
+    it('should sort by aggregate alias', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY cnt DESC' }))
       // NYC has 3 users, LA has 2
       expect(result[0].city).toBe('NYC')
       expect(result[0].cnt).toBe(3)
     })
 
-    // it('should sort by aggregate expression', () => {
-    //   const result = executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY COUNT(*) DESC' })
+    // it('should sort by aggregate expression', async () => {
+    //   const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY COUNT(*) DESC' }))
     //   expect(result[0].city).toBe('NYC')
     //   expect(result[0].cnt).toBe(3)
     // })
   })
 
   describe('NULLS FIRST and NULLS LAST', () => {
-    it('should handle NULLS FIRST with ASC', () => {
+    it('should handle NULLS FIRST with ASC', async () => {
       const data = [
         { id: 1, value: 10 },
         { id: 2, value: null },
@@ -105,7 +105,7 @@ describe('ORDER BY', () => {
         { id: 4, value: null },
         { id: 5, value: 20 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value ASC NULLS FIRST' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value ASC NULLS FIRST' }))
       expect(result[0].value).toBe(null)
       expect(result[1].value).toBe(null)
       expect(result[2].value).toBe(5)
@@ -113,7 +113,7 @@ describe('ORDER BY', () => {
       expect(result[4].value).toBe(20)
     })
 
-    it('should handle NULLS LAST with ASC', () => {
+    it('should handle NULLS LAST with ASC', async () => {
       const data = [
         { id: 1, value: 10 },
         { id: 2, value: null },
@@ -121,7 +121,7 @@ describe('ORDER BY', () => {
         { id: 4, value: null },
         { id: 5, value: 20 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value ASC NULLS LAST' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value ASC NULLS LAST' }))
       expect(result[0].value).toBe(5)
       expect(result[1].value).toBe(10)
       expect(result[2].value).toBe(20)
@@ -129,7 +129,7 @@ describe('ORDER BY', () => {
       expect(result[4].value).toBe(null)
     })
 
-    it('should handle NULLS FIRST with DESC', () => {
+    it('should handle NULLS FIRST with DESC', async () => {
       const data = [
         { id: 1, value: 10 },
         { id: 2, value: null },
@@ -137,7 +137,7 @@ describe('ORDER BY', () => {
         { id: 4, value: null },
         { id: 5, value: 20 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value DESC NULLS FIRST' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value DESC NULLS FIRST' }))
       expect(result[0].value).toBe(null)
       expect(result[1].value).toBe(null)
       expect(result[2].value).toBe(20)
@@ -145,7 +145,7 @@ describe('ORDER BY', () => {
       expect(result[4].value).toBe(5)
     })
 
-    it('should handle NULLS LAST with DESC', () => {
+    it('should handle NULLS LAST with DESC', async () => {
       const data = [
         { id: 1, value: 10 },
         { id: 2, value: null },
@@ -153,7 +153,7 @@ describe('ORDER BY', () => {
         { id: 4, value: null },
         { id: 5, value: 20 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value DESC NULLS LAST' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value DESC NULLS LAST' }))
       expect(result[0].value).toBe(20)
       expect(result[1].value).toBe(10)
       expect(result[2].value).toBe(5)

--- a/test/execute/execute.strings.test.js
+++ b/test/execute/execute.strings.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 /** @type {null} */
 const NULL = null
@@ -13,8 +13,8 @@ describe('string functions', () => {
   ]
 
   describe('UPPER', () => {
-    it('should convert column values to uppercase', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT UPPER(name) AS upper_name FROM users' })
+    it('should convert column values to uppercase', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT UPPER(name) AS upper_name FROM users' }))
       expect(result).toEqual([
         { upper_name: 'ALICE' },
         { upper_name: 'BOB' },
@@ -23,33 +23,33 @@ describe('string functions', () => {
       ])
     })
 
-    it('should work without alias', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT UPPER(city) FROM users' })
+    it('should work without alias', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT UPPER(city) FROM users' }))
       expect(result[0]).toHaveProperty('upper_city')
       expect(result[0].upper_city).toBe('NYC')
     })
 
-    it('should handle mixed case input', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT UPPER(email) AS upper_email FROM users WHERE id = 4' })
+    it('should handle mixed case input', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT UPPER(email) AS upper_email FROM users WHERE id = 4' }))
       expect(result[0].upper_email).toBe('DIANA@EXAMPLE.COM')
     })
 
-    it('should work with WHERE clause', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, UPPER(city) AS upper_city FROM users WHERE city = \'NYC\'' })
+    it('should work with WHERE clause', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name, UPPER(city) AS upper_city FROM users WHERE city = \'NYC\'' }))
       expect(result).toHaveLength(2)
       expect(result.every(r => r.upper_city === 'NYC')).toBe(true)
     })
 
-    it('should work with ORDER BY', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT UPPER(name) AS upper_name FROM users ORDER BY name' })
+    it('should work with ORDER BY', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT UPPER(name) AS upper_name FROM users ORDER BY name' }))
       expect(result[0].upper_name).toBe('ALICE')
       expect(result[result.length - 1].upper_name).toBe('DIANA')
     })
   })
 
   describe('LOWER', () => {
-    it('should convert column values to lowercase', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT LOWER(name) AS lower_name FROM users' })
+    it('should convert column values to lowercase', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT LOWER(name) AS lower_name FROM users' }))
       expect(result).toEqual([
         { lower_name: 'alice' },
         { lower_name: 'bob' },
@@ -58,19 +58,19 @@ describe('string functions', () => {
       ])
     })
 
-    it('should work without alias', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT LOWER(city) FROM users' })
+    it('should work without alias', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT LOWER(city) FROM users' }))
       expect(result[0]).toHaveProperty('lower_city')
       expect(result[0].lower_city).toBe('nyc')
     })
 
-    it('should handle mixed case input', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT LOWER(email) AS lower_email FROM users WHERE id = 4' })
+    it('should handle mixed case input', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT LOWER(email) AS lower_email FROM users WHERE id = 4' }))
       expect(result[0].lower_email).toBe('diana@example.com')
     })
 
-    it('should work with multiple columns', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT id, LOWER(name) AS lower_name, LOWER(city) AS lower_city FROM users WHERE id = 1' })
+    it('should work with multiple columns', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT id, LOWER(name) AS lower_name, LOWER(city) AS lower_city FROM users WHERE id = 1' }))
       expect(result[0]).toEqual({
         id: 1,
         lower_name: 'alice',
@@ -80,52 +80,52 @@ describe('string functions', () => {
   })
 
   describe('CONCAT', () => {
-    it('should concatenate two columns', () => {
+    it('should concatenate two columns', async () => {
       const users = [
         { id: 1, first_name: 'Alice', last_name: 'Smith' },
         { id: 2, first_name: 'Bob', last_name: 'Jones' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT CONCAT(first_name, last_name) AS full_name FROM users' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT CONCAT(first_name, last_name) AS full_name FROM users' }))
       expect(result).toEqual([
         { full_name: 'AliceSmith' },
         { full_name: 'BobJones' },
       ])
     })
 
-    it('should concatenate columns with string literals', () => {
+    it('should concatenate columns with string literals', async () => {
       const users = [
         { id: 1, first_name: 'Alice', last_name: 'Smith' },
         { id: 2, first_name: 'Bob', last_name: 'Jones' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT CONCAT(first_name, \' \', last_name) AS full_name FROM users' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT CONCAT(first_name, \' \', last_name) AS full_name FROM users' }))
       expect(result).toEqual([
         { full_name: 'Alice Smith' },
         { full_name: 'Bob Jones' },
       ])
     })
 
-    it('should concatenate multiple columns and literals', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT CONCAT(name, \' (\', city, \')\') AS name_city FROM users WHERE id = 1' })
+    it('should concatenate multiple columns and literals', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT CONCAT(name, \' (\', city, \')\') AS name_city FROM users WHERE id = 1' }))
       expect(result[0].name_city).toBe('Alice (NYC)')
     })
 
-    it('should work without alias', () => {
+    it('should work without alias', async () => {
       const data = [{ id: 1, a: 'hello', b: 'world' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT CONCAT(a, b) FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT CONCAT(a, b) FROM data' }))
       expect(result[0]).toHaveProperty('concat_a_b')
       expect(result[0].concat_a_b).toBe('helloworld')
     })
 
-    it('should handle empty strings', () => {
+    it('should handle empty strings', async () => {
       const data = [{ id: 1, a: '', b: 'test' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT CONCAT(a, b) AS result FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT CONCAT(a, b) AS result FROM data' }))
       expect(result[0].result).toBe('test')
     })
   })
 
   describe('LENGTH', () => {
-    it('should return length of string column', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT LENGTH(name) AS name_length FROM users' })
+    it('should return length of string column', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT LENGTH(name) AS name_length FROM users' }))
       expect(result).toEqual([
         { name_length: 5 }, // Alice
         { name_length: 3 }, // Bob
@@ -134,116 +134,116 @@ describe('string functions', () => {
       ])
     })
 
-    it('should work without alias', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT LENGTH(city) FROM users' })
+    it('should work without alias', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT LENGTH(city) FROM users' }))
       expect(result[0]).toHaveProperty('length_city')
       expect(result[0].length_city).toBe(3) // NYC
     })
 
-    it('should work with WHERE clause', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, LENGTH(name) AS name_length FROM users WHERE LENGTH(name) > 5' })
+    it('should work with WHERE clause', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name, LENGTH(name) AS name_length FROM users WHERE LENGTH(name) > 5' }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Charlie')
     })
 
-    it('should work with ORDER BY', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, LENGTH(name) AS name_length FROM users ORDER BY LENGTH(name) DESC' })
+    it('should work with ORDER BY', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name, LENGTH(name) AS name_length FROM users ORDER BY LENGTH(name) DESC' }))
       expect(result[0].name).toBe('Charlie')
       expect(result[result.length - 1].name).toBe('Bob')
     })
 
-    it('should handle empty strings', () => {
+    it('should handle empty strings', async () => {
       const data = [{ id: 1, value: '' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT LENGTH(value) AS len FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT LENGTH(value) AS len FROM data' }))
       expect(result[0].len).toBe(0)
     })
   })
 
   describe('SUBSTRING', () => {
-    it('should extract substring with start position', () => {
+    it('should extract substring with start position', async () => {
       const data = [
         { id: 1, text: 'Hello World' },
         { id: 2, text: 'JavaScript' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 5) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 5) AS sub FROM data' }))
       expect(result).toEqual([
         { sub: 'Hello' },
         { sub: 'JavaS' },
       ])
     })
 
-    it('should extract substring from middle', () => {
+    it('should extract substring from middle', async () => {
       const data = [{ id: 1, text: 'Hello World' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 7, 5) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 7, 5) AS sub FROM data' }))
       expect(result[0].sub).toBe('World')
     })
 
-    it('should work without alias', () => {
+    it('should work without alias', async () => {
       const data = [{ id: 1, text: 'Hello' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 3) FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 3) FROM data' }))
       expect(result[0]).toHaveProperty('substring_text')
       expect(result[0].substring_text).toBe('Hel')
     })
 
-    it('should handle substring beyond string length', () => {
+    it('should handle substring beyond string length', async () => {
       const data = [{ id: 1, text: 'Hi' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 10) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 10) AS sub FROM data' }))
       expect(result[0].sub).toBe('Hi')
     })
 
-    it('should work with column names', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, SUBSTRING(email, 1, 5) AS email_prefix FROM users WHERE id = 1' })
+    it('should work with column names', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name, SUBSTRING(email, 1, 5) AS email_prefix FROM users WHERE id = 1' }))
       expect(result[0].email_prefix).toBe('alice')
     })
   })
 
   describe('SUBSTR', () => {
-    it('should work as an alias for SUBSTRING', () => {
+    it('should work as an alias for SUBSTRING', async () => {
       const data = [
         { id: 1, text: 'Hello World' },
         { id: 2, text: 'JavaScript' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 1, 5) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 1, 5) AS sub FROM data' }))
       expect(result).toEqual([
         { sub: 'Hello' },
         { sub: 'JavaS' },
       ])
     })
 
-    it('should extract substring from middle', () => {
+    it('should extract substring from middle', async () => {
       const data = [{ id: 1, text: 'Hello World' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 7, 5) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 7, 5) AS sub FROM data' }))
       expect(result[0].sub).toBe('World')
     })
 
-    it('should work without length parameter', () => {
+    it('should work without length parameter', async () => {
       const data = [{ id: 1, text: 'Hello World' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 7) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 7) AS sub FROM data' }))
       expect(result[0].sub).toBe('World')
     })
 
-    it('should work without alias', () => {
+    it('should work without alias', async () => {
       const data = [{ id: 1, text: 'Hello' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 1, 3) FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 1, 3) FROM data' }))
       expect(result[0]).toHaveProperty('substr_text')
       expect(result[0].substr_text).toBe('Hel')
     })
 
-    it('should handle null values', () => {
+    it('should handle null values', async () => {
       const data = [{ id: 1, text: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 1, 5) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTR(text, 1, 5) AS sub FROM data' }))
       expect(result[0].sub).toBeNull()
     })
   })
 
   describe('TRIM', () => {
-    it('should remove leading and trailing whitespace', () => {
+    it('should remove leading and trailing whitespace', async () => {
       const data = [
         { id: 1, text: '  hello  ' },
         { id: 2, text: '\tworld\t' },
         { id: 3, text: '\n test \n' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' }))
       expect(result).toEqual([
         { trimmed: 'hello' },
         { trimmed: 'world' },
@@ -251,135 +251,135 @@ describe('string functions', () => {
       ])
     })
 
-    it('should work without alias', () => {
+    it('should work without alias', async () => {
       const data = [{ id: 1, text: '  hello  ' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT TRIM(text) FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT TRIM(text) FROM data' }))
       expect(result[0]).toHaveProperty('trim_text')
       expect(result[0].trim_text).toBe('hello')
     })
 
-    it('should not affect strings without whitespace', () => {
+    it('should not affect strings without whitespace', async () => {
       const data = [{ id: 1, text: 'hello' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' }))
       expect(result[0].trimmed).toBe('hello')
     })
 
-    it('should preserve internal whitespace', () => {
+    it('should preserve internal whitespace', async () => {
       const data = [{ id: 1, text: '  hello world  ' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' }))
       expect(result[0].trimmed).toBe('hello world')
     })
 
-    it('should work with WHERE clause', () => {
+    it('should work with WHERE clause', async () => {
       const users = [
         { id: 1, name: '  Alice  ' },
         { id: 2, name: 'Bob' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT id, TRIM(name) AS trimmed FROM users WHERE TRIM(name) = \'Alice\'' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT id, TRIM(name) AS trimmed FROM users WHERE TRIM(name) = \'Alice\'' }))
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe(1)
     })
   })
 
   describe('REPLACE', () => {
-    it('should replace all occurrences of a substring', () => {
+    it('should replace all occurrences of a substring', async () => {
       const data = [
         { id: 1, text: 'Hello World' },
         { id: 2, text: 'foo bar foo' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'o\', \'0\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'o\', \'0\') AS replaced FROM data' }))
       expect(result).toEqual([
         { replaced: 'Hell0 W0rld' },
         { replaced: 'f00 bar f00' },
       ])
     })
 
-    it('should replace multiple character substrings', () => {
+    it('should replace multiple character substrings', async () => {
       const data = [{ id: 1, text: 'Hello World Hello' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'Hello\', \'Hi\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'Hello\', \'Hi\') AS replaced FROM data' }))
       expect(result[0].replaced).toBe('Hi World Hi')
     })
 
-    it('should work without alias', () => {
+    it('should work without alias', async () => {
       const data = [{ id: 1, text: 'test' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'t\', \'T\') FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'t\', \'T\') FROM data' }))
       expect(result[0]).toHaveProperty('replace_text')
       expect(result[0].replace_text).toBe('TesT')
     })
 
-    it('should handle empty replacement string', () => {
+    it('should handle empty replacement string', async () => {
       const data = [{ id: 1, text: 'Hello World' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \' \', \'\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \' \', \'\') AS replaced FROM data' }))
       expect(result[0].replaced).toBe('HelloWorld')
     })
 
-    it('should handle search string not found', () => {
+    it('should handle search string not found', async () => {
       const data = [{ id: 1, text: 'Hello World' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'xyz\', \'abc\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'xyz\', \'abc\') AS replaced FROM data' }))
       expect(result[0].replaced).toBe('Hello World')
     })
 
-    it('should work with column values', () => {
+    it('should work with column values', async () => {
       const data = [
         { id: 1, email: 'alice@example.com', old_domain: 'example.com', new_domain: 'test.org' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(email, old_domain, new_domain) AS new_email FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(email, old_domain, new_domain) AS new_email FROM data' }))
       expect(result[0].new_email).toBe('alice@test.org')
     })
 
-    it('should work with WHERE clause', () => {
+    it('should work with WHERE clause', async () => {
       const data = [
         { id: 1, text: 'apple banana' },
         { id: 2, text: 'grape orange' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'a\', \'@\') AS replaced FROM data WHERE text LIKE \'%apple%\'' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'a\', \'@\') AS replaced FROM data WHERE text LIKE \'%apple%\'' }))
       expect(result).toHaveLength(1)
       expect(result[0].replaced).toBe('@pple b@n@n@')
     })
 
-    it('should work with ORDER BY', () => {
+    it('should work with ORDER BY', async () => {
       const data = [
         { id: 1, name: 'Alice' },
         { id: 2, name: 'Bob' },
         { id: 3, name: 'Carol' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(name, \'o\', \'0\') AS replaced FROM data ORDER BY name' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(name, \'o\', \'0\') AS replaced FROM data ORDER BY name' }))
       expect(result[0].replaced).toBe('Alice')
       expect(result[1].replaced).toBe('B0b')
       expect(result[2].replaced).toBe('Car0l')
     })
 
-    it('should be case-sensitive', () => {
+    it('should be case-sensitive', async () => {
       const data = [{ id: 1, text: 'Hello hello HELLO' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'hello\', \'hi\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'hello\', \'hi\') AS replaced FROM data' }))
       expect(result[0].replaced).toBe('Hello hi HELLO')
     })
 
-    it('should handle null values in first argument', () => {
+    it('should handle null values in first argument', async () => {
       const data = [{ id: 1, text: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'a\', \'b\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'a\', \'b\') AS replaced FROM data' }))
       expect(result[0].replaced).toBeNull()
     })
 
-    it('should handle null values in second argument', () => {
+    it('should handle null values in second argument', async () => {
       const data = [{ id: 1, text: 'hello', search: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, search, \'x\') AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, search, \'x\') AS replaced FROM data' }))
       expect(result[0].replaced).toBeNull()
     })
 
-    it('should handle null values in third argument', () => {
+    it('should handle null values in third argument', async () => {
       const data = [{ id: 1, text: 'hello', replacement: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'l\', replacement) AS replaced FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT REPLACE(text, \'l\', replacement) AS replaced FROM data' }))
       expect(result[0].replaced).toBeNull()
     })
   })
 
   describe('combined string functions', () => {
-    it('should use multiple different string functions in one query', () => {
-      const result = executeSql({
+    it('should use multiple different string functions in one query', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT UPPER(name) AS upper_name, LOWER(city) AS lower_city, LENGTH(email) AS email_len FROM users WHERE id = 1',
-      })
+      }))
       expect(result[0]).toEqual({
         upper_name: 'ALICE',
         lower_city: 'nyc',
@@ -387,15 +387,15 @@ describe('string functions', () => {
       })
     })
 
-    it('should work with regular columns', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT id, name, UPPER(city) AS upper_city FROM users ORDER BY id LIMIT 2' })
+    it('should work with regular columns', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT id, name, UPPER(city) AS upper_city FROM users ORDER BY id LIMIT 2' }))
       expect(result).toHaveLength(2)
       expect(result[0]).toEqual({ id: 1, name: 'Alice', upper_city: 'NYC' })
       expect(result[1]).toEqual({ id: 2, name: 'Bob', upper_city: 'LA' })
     })
 
-    it('should work with DISTINCT', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT DISTINCT UPPER(city) AS upper_city FROM users' })
+    it('should work with DISTINCT', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT DISTINCT UPPER(city) AS upper_city FROM users' }))
       expect(result).toHaveLength(2)
       const cities = result.map(r => r.upper_city).sort()
       expect(cities).toEqual(['LA', 'NYC'])
@@ -403,20 +403,20 @@ describe('string functions', () => {
   })
 
   describe('string functions with GROUP BY', () => {
-    it('should work with GROUP BY and aggregates', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT UPPER(city) AS upper_city, COUNT(*) AS count FROM users GROUP BY city' })
+    it('should work with GROUP BY and aggregates', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT UPPER(city) AS upper_city, COUNT(*) AS count FROM users GROUP BY city' }))
       expect(result).toHaveLength(2)
       const nycGroup = result.find(r => r.upper_city === 'NYC')
       expect(nycGroup?.count).toBe(2)
     })
 
-    it('should group by string function result', () => {
+    it('should group by string function result', async () => {
       const data = [
         { id: 1, name: 'alice', value: 10 },
         { id: 2, name: 'ALICE', value: 20 },
         { id: 3, name: 'bob', value: 30 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT UPPER(name) AS upper_name, SUM(value) AS total FROM data GROUP BY UPPER(name)' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT UPPER(name) AS upper_name, SUM(value) AS total FROM data GROUP BY UPPER(name)' }))
       expect(result).toHaveLength(2)
       const aliceGroup = result.find(r => r.upper_name === 'ALICE')
       expect(aliceGroup?.total).toBe(30)
@@ -424,45 +424,45 @@ describe('string functions', () => {
   })
 
   describe('null handling', () => {
-    it('should handle null values in UPPER', () => {
+    it('should handle null values in UPPER', async () => {
       const data = [
         { id: 1, name: 'Alice' },
         { id: 2, name: null },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT UPPER(name) AS upper_name FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT UPPER(name) AS upper_name FROM data' }))
       expect(result[1].upper_name).toBeNull()
     })
 
-    it('should handle null values in LOWER', () => {
+    it('should handle null values in LOWER', async () => {
       const data = [
         { id: 1, name: 'Alice' },
         { id: 2, name: null },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT LOWER(name) AS lower_name FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT LOWER(name) AS lower_name FROM data' }))
       expect(result[1].lower_name).toBeNull()
     })
 
-    it('should handle null values in CONCAT', () => {
+    it('should handle null values in CONCAT', async () => {
       const data = [{ id: 1, first: 'Alice', last: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT CONCAT(first, last) AS full FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT CONCAT(first, last) AS full FROM data' }))
       expect(result[0].full).toBeNull()
     })
 
-    it('should handle null values in LENGTH', () => {
+    it('should handle null values in LENGTH', async () => {
       const data = [{ id: 1, text: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT LENGTH(text) AS len FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT LENGTH(text) AS len FROM data' }))
       expect(result[0].len).toBeNull()
     })
 
-    it('should handle null values in SUBSTRING', () => {
+    it('should handle null values in SUBSTRING', async () => {
       const data = [{ id: 1, text: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 5) AS sub FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT SUBSTRING(text, 1, 5) AS sub FROM data' }))
       expect(result[0].sub).toBeNull()
     })
 
-    it('should handle null values in TRIM', () => {
+    it('should handle null values in TRIM', async () => {
       const data = [{ id: 1, text: NULL }]
-      const result = executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT TRIM(text) AS trimmed FROM data' }))
       expect(result[0].trimmed).toBeNull()
     })
   })

--- a/test/execute/execute.subquery.test.js
+++ b/test/execute/execute.subquery.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/index.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('subqueries', () => {
   const users = [
@@ -16,34 +16,34 @@ describe('subqueries', () => {
   ]
 
   describe('FROM clause subquery (derived table)', () => {
-    it('should execute simple derived table', () => {
-      const result = executeSql({
+    it('should execute simple derived table', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT name FROM (SELECT * FROM users WHERE age > 25) AS older_users',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie'])
     })
 
-    it('should handle derived table with column selection', () => {
-      const result = executeSql({
+    it('should handle derived table with column selection', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT name, age FROM (SELECT name, age FROM users WHERE active = TRUE) AS active_users',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Bob'])
     })
 
-    it('should handle derived table with aggregates', () => {
-      const result = executeSql({
+    it('should handle derived table with aggregates', async () => {
+      const result = await collect(executeSql({
         tables: { orders },
         query: 'SELECT * FROM (SELECT user_id, SUM(amount) AS total FROM orders GROUP BY user_id) AS user_totals',
-      })
+      }))
       expect(result).toHaveLength(3)
     })
 
-    it('should allow filtering on derived table', () => {
-      const result = executeSql({
+    it('should allow filtering on derived table', async () => {
+      const result = await collect(executeSql({
         tables: { orders },
         query: `
           SELECT * FROM (
@@ -53,24 +53,24 @@ describe('subqueries', () => {
           ) AS user_totals
           WHERE total > 100
         `,
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.user_id).sort()).toEqual([1, 2])
     })
 
-    it('should handle empty derived table', () => {
-      const result = executeSql({
+    it('should handle empty derived table', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM (SELECT * FROM users WHERE age > 100) AS empty',
-      })
+      }))
       expect(result).toHaveLength(0)
     })
 
-    it('should handle derived table with ORDER BY in outer query', () => {
-      const result = executeSql({
+    it('should handle derived table with ORDER BY in outer query', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT name, age FROM (SELECT * FROM users) AS all_users ORDER BY age DESC',
-      })
+      }))
       expect(result).toHaveLength(3)
       expect(result[0].name).toBe('Charlie')
       expect(result[2].name).toBe('Bob')
@@ -78,200 +78,204 @@ describe('subqueries', () => {
   })
 
   describe('IN subquery', () => {
-    it('should filter with IN subquery', () => {
-      const result = executeSql({
+    it('should filter with IN subquery', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Bob'])
     })
 
-    it('should handle IN subquery with WHERE clause', () => {
-      const result = executeSql({
+    it('should handle IN subquery with WHERE clause', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders WHERE amount > 150)',
-      })
+      }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Bob')
     })
 
-    it('should handle IN subquery returning no rows', () => {
-      const result = executeSql({
+    it('should handle IN subquery returning no rows', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders WHERE amount > 1000)',
-      })
+      }))
       expect(result).toHaveLength(0)
     })
 
-    it('should handle IN subquery with multiple matches', () => {
-      const result = executeSql({
+    it('should handle IN subquery with multiple matches', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM orders WHERE user_id IN (SELECT id FROM users WHERE active = TRUE)',
-      })
+      }))
       expect(result).toHaveLength(3) // orders 1, 2, 3
     })
 
-    it('should work with IN subquery on non-id columns', () => {
-      const result = executeSql({
+    it('should work with IN subquery on non-id columns', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM orders WHERE amount IN (SELECT age FROM users)',
-      })
+      }))
       // age values: 30, 25, 35 - no orders match these amounts
       expect(result).toHaveLength(0)
     })
   })
 
   describe('NOT IN subquery', () => {
-    it('should filter with NOT IN subquery', () => {
-      const result = executeSql({
+    it('should filter with NOT IN subquery', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id NOT IN (SELECT user_id FROM orders)',
-      })
+      }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Charlie')
     })
 
-    it('should handle NOT IN with filtered subquery', () => {
-      const result = executeSql({
+    it('should handle NOT IN with filtered subquery', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id NOT IN (SELECT user_id FROM orders WHERE amount > 150)',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie'])
     })
 
-    it('should return all rows when NOT IN subquery is empty', () => {
-      const result = executeSql({
+    it('should return all rows when NOT IN subquery is empty', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id NOT IN (SELECT user_id FROM orders WHERE amount > 1000)',
-      })
+      }))
       expect(result).toHaveLength(3)
     })
   })
 
   describe('EXISTS subquery', () => {
-    it('should return all rows when EXISTS subquery has results', () => {
-      const result = executeSql({
+    it('should return all rows when EXISTS subquery has results', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE EXISTS (SELECT * FROM orders)',
-      })
+      }))
       expect(result).toHaveLength(3) // all users
     })
 
-    it('should return no rows when EXISTS subquery is empty', () => {
-      const result = executeSql({
+    it('should return no rows when EXISTS subquery is empty', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE EXISTS (SELECT * FROM orders WHERE amount > 1000)',
-      })
+      }))
       expect(result).toHaveLength(0)
     })
 
-    it('should handle EXISTS with filtered subquery', () => {
-      const result = executeSql({
+    it('should handle EXISTS with filtered subquery', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE EXISTS (SELECT * FROM orders WHERE amount > 100)',
-      })
+      }))
       expect(result).toHaveLength(3)
     })
   })
 
   describe('NOT EXISTS subquery', () => {
-    it('should return no rows when NOT EXISTS subquery has results', () => {
-      const result = executeSql({
+    it('should return no rows when NOT EXISTS subquery has results', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE NOT EXISTS (SELECT * FROM orders)',
-      })
+      }))
       expect(result).toHaveLength(0)
     })
 
-    it('should return all rows when NOT EXISTS subquery is empty', () => {
-      const result = executeSql({
+    it('should return all rows when NOT EXISTS subquery is empty', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE NOT EXISTS (SELECT * FROM orders WHERE amount > 1000)',
-      })
+      }))
       expect(result).toHaveLength(3)
     })
   })
 
   describe('error cases', () => {
-    it('should throw error for subquery referencing unknown table', () => {
-      expect(() => executeSql({
-        tables: { users },
-        query: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)',
-      })).toThrow('Table "orders" not found')
+    it('should throw error for subquery referencing unknown table', async () => {
+      await expect(async () => {
+        await collect(executeSql({
+          tables: { users },
+          query: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)',
+        }))
+      }).rejects.toThrow('Table "orders" not found')
     })
 
-    it('should support nested subqueries in FROM', () => {
-      const result = executeSql({
+    it('should support nested subqueries in FROM', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM (SELECT * FROM (SELECT * FROM users) AS sub1) AS sub2',
-      })
+      }))
       expect(result).toEqual(users)
     })
 
-    it('should throw error for unknown table in FROM subquery', () => {
-      expect(() => executeSql({
-        tables: { users },
-        query: 'SELECT * FROM (SELECT * FROM nonexistent) AS sub',
-      })).toThrow('Table "nonexistent" not found')
+    it('should throw error for unknown table in FROM subquery', async () => {
+      await expect(async () => {
+        await collect(executeSql({
+          tables: { users },
+          query: 'SELECT * FROM (SELECT * FROM nonexistent) AS sub',
+        }))
+      }).rejects.toThrow('Table "nonexistent" not found')
     })
   })
 
   describe('complex scenarios', () => {
-    it('should combine IN subquery with other WHERE conditions', () => {
-      const result = executeSql({
+    it('should combine IN subquery with other WHERE conditions', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders) AND age > 27',
-      })
+      }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Alice')
     })
 
-    it('should handle subquery in OR condition', () => {
-      const result = executeSql({
+    it('should handle subquery in OR condition', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE age > 34 OR id IN (SELECT user_id FROM orders WHERE amount > 150)',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Charlie'])
     })
 
-    it('should combine EXISTS with AND condition', () => {
-      const result = executeSql({
+    it('should combine EXISTS with AND condition', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: 'SELECT * FROM users WHERE EXISTS (SELECT * FROM orders WHERE amount > 100) AND active = TRUE',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Bob'])
     })
 
-    it('should handle multiple subqueries in same query', () => {
-      const result = executeSql({
+    it('should handle multiple subqueries in same query', async () => {
+      const result = await collect(executeSql({
         tables: { users, orders },
         query: `
           SELECT * FROM users
           WHERE id IN (SELECT user_id FROM orders)
           AND id NOT IN (SELECT user_id FROM orders WHERE amount > 150)
         `,
-      })
+      }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Alice')
     })
 
-    it('should handle derived table with DISTINCT', () => {
-      const result = executeSql({
+    it('should handle derived table with DISTINCT', async () => {
+      const result = await collect(executeSql({
         tables: { orders },
         query: 'SELECT * FROM (SELECT DISTINCT user_id FROM orders) AS unique_users',
-      })
+      }))
       expect(result).toHaveLength(3)
     })
 
-    it('should handle derived table with LIMIT', () => {
-      const result = executeSql({
+    it('should handle derived table with LIMIT', async () => {
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM (SELECT * FROM users ORDER BY age DESC LIMIT 2) AS top_users',
-      })
+      }))
       expect(result).toHaveLength(2)
     })
   })

--- a/test/execute/execute.test.js
+++ b/test/execute/execute.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('executeSql', () => {
   const users = [
@@ -11,18 +11,27 @@ describe('executeSql', () => {
   ]
 
   describe('basic SELECT queries', () => {
-    it('should select all columns', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users' })
+    it('should select all columns', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: 'SELECT * FROM users',
+      }))
       expect(result).toEqual(users)
     })
 
-    it('should select all columns with qualified asterisk', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT users.* FROM users' })
+    it('should select all columns with qualified asterisk', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: 'SELECT users.* FROM users',
+      }))
       expect(result).toEqual(users)
     })
 
-    it('should select specific columns', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, age FROM users' })
+    it('should select specific columns', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: 'SELECT name, age FROM users',
+      }))
       expect(result).toEqual([
         { name: 'Alice', age: 30 },
         { name: 'Bob', age: 25 },
@@ -32,308 +41,320 @@ describe('executeSql', () => {
       ])
     })
 
-    it('should handle column aliases', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name AS fullName, age AS years FROM users' })
+    it('should handle column aliases', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: 'SELECT name AS fullName, age AS years FROM users',
+      }))
       expect(result[0]).toEqual({ fullName: 'Alice', years: 30 })
     })
 
-    it('should handle empty dataset', () => {
-      const result = executeSql({ tables: { users: [] }, query: 'SELECT * FROM users' })
+    it('should handle empty dataset', async () => {
+      const result = await collect(executeSql({
+        tables: { users: [] },
+        query: 'SELECT * FROM users',
+      }))
       expect(result).toEqual([])
     })
 
-    it('should error selecting from non-existent table', () => {
-      expect(() => executeSql({ tables: { users }, query: 'SELECT * FROM orders' }))
-        .toThrow('Table "orders" not found')
+    it('should error selecting from non-existent table', async () => {
+      await expect(async () => {
+        await collect(executeSql({ tables: { users }, query: 'SELECT * FROM orders' }))
+      }).rejects.toThrow('Table "orders" not found')
     })
   })
 
   describe('DISTINCT', () => {
-    it('should return distinct rows', () => {
+    it('should return distinct rows', async () => {
       const data = [
         { city: 'NYC', age: 30 },
         { city: 'LA', age: 25 },
         { city: 'NYC', age: 30 },
         { city: 'LA', age: 25 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT DISTINCT city, age FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT DISTINCT city, age FROM data' }))
       expect(result).toHaveLength(2)
     })
 
-    it('should handle DISTINCT with single column', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT DISTINCT city FROM users' })
+    it('should handle DISTINCT with single column', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT DISTINCT city FROM users' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.city).sort()).toEqual(['LA', 'NYC'])
     })
 
-    it('should not affect non-distinct queries', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT city FROM users' })
+    it('should not affect non-distinct queries', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT city FROM users' }))
       expect(result).toHaveLength(5)
     })
   })
 
   describe('LIMIT and OFFSET', () => {
-    it('should limit results', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users LIMIT 2' })
+    it('should limit results', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users LIMIT 2' }))
       expect(result).toHaveLength(2)
     })
 
-    it('should apply offset', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users OFFSET 2' })
+    it('should apply offset', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users OFFSET 2' }))
       expect(result).toHaveLength(3)
     })
 
-    it('should apply both LIMIT and OFFSET', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY name LIMIT 2 OFFSET 1' })
+    it('should apply both LIMIT and OFFSET', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users ORDER BY name LIMIT 2 OFFSET 1' }))
       expect(result).toHaveLength(2)
       expect(result[0].name).toBe('Bob')
       expect(result[1].name).toBe('Charlie')
     })
 
-    it('should handle LIMIT larger than result set', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users LIMIT 100' })
+    it('should handle LIMIT larger than result set', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users LIMIT 100' }))
       expect(result).toHaveLength(5)
     })
 
-    it('should handle OFFSET larger than result set', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users OFFSET 100' })
+    it('should handle OFFSET larger than result set', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users OFFSET 100' }))
       expect(result).toHaveLength(0)
     })
   })
 
   describe('complex queries', () => {
-    it('should handle WHERE + GROUP BY + ORDER BY + LIMIT', () => {
-      const result = executeSql({ tables: { users }, query: `
+    it('should handle WHERE + GROUP BY + ORDER BY + LIMIT', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: `
         SELECT city, COUNT(*) AS count
         FROM users
         WHERE age >= 28
         GROUP BY city
         ORDER BY count DESC
         LIMIT 1
-      ` })
+      ` }))
       expect(result).toHaveLength(1)
       expect(result[0].city).toBe('NYC')
       expect(result[0].count).toBe(3)
     })
 
-    it('should handle DISTINCT + ORDER BY + LIMIT', () => {
-      const result = executeSql({ tables: { users }, query: `
+    it('should handle DISTINCT + ORDER BY + LIMIT', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: `
         SELECT DISTINCT age
         FROM users
         ORDER BY age DESC
         LIMIT 3
-      ` })
+      ` }))
       expect(result).toHaveLength(3)
       expect(result[0].age).toBe(35)
     })
 
-    it('should apply operations in correct order', () => {
+    it('should apply operations in correct order', async () => {
       // WHERE -> DISTINCT -> ORDER BY -> LIMIT -> OFFSET
-      const result = executeSql({ tables: { users }, query: 'SELECT age FROM users WHERE city = \'NYC\' ORDER BY age LIMIT 1 OFFSET 1' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT age FROM users WHERE city = \'NYC\' ORDER BY age LIMIT 1 OFFSET 1' }))
       expect(result).toHaveLength(1)
       expect(result[0].age).toBe(30) // Second age value after sorting (30, 30, 35)
     })
   })
 
   describe('error cases', () => {
-    it('should throw error for SUM with star', () => {
-      expect(() => executeSql({ tables: { users }, query: 'SELECT SUM(*) FROM users' }))
-        .toThrow('SUM(*) is not supported')
+    it('should throw error for SUM with star', async () => {
+      await expect(async () => {
+        await collect(executeSql({ tables: { users }, query: 'SELECT SUM(*) FROM users' }))
+      }).rejects.toThrow('SUM(*) is not supported')
     })
 
-    it('should throw error for AVG with star', () => {
-      expect(() => executeSql({ tables: { users }, query: 'SELECT AVG(*) FROM users' }))
-        .toThrow('AVG(*) is not supported')
+    it('should throw error for AVG with star', async () => {
+      await expect(async () => {
+        await collect(executeSql({ tables: { users }, query: 'SELECT AVG(*) FROM users' }))
+      }).rejects.toThrow('AVG(*) is not supported')
     })
 
-    it('should throw error for MIN with star', () => {
-      expect(() => executeSql({ tables: { users }, query: 'SELECT MIN(*) FROM users' }))
-        .toThrow('MIN(*) is not supported')
+    it('should throw error for MIN with star', async () => {
+      await expect(async () => {
+        await collect(executeSql({ tables: { users }, query: 'SELECT MIN(*) FROM users' }))
+      }).rejects.toThrow('MIN(*) is not supported')
     })
 
-    it('should throw error for MAX with star', () => {
-      expect(() => executeSql({ tables: { users }, query: 'SELECT MAX(*) FROM users' }))
-        .toThrow('MAX(*) is not supported')
+    it('should throw error for MAX with star', async () => {
+      await expect(async () => {
+        await collect(executeSql({ tables: { users }, query: 'SELECT MAX(*) FROM users' }))
+      }).rejects.toThrow('MAX(*) is not supported')
     })
   })
 
   describe('JOIN queries', () => {
-    it('should throw error for JOIN queries', () => {
-      expect(() => executeSql({ tables: { users }, query: 'SELECT * FROM users JOIN orders ON users.id = orders.user_id' }))
-        .toThrow('JOIN is not supported')
+    it('should throw error for JOIN queries', async () => {
+      await expect(async () => {
+        await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users JOIN orders ON users.id = orders.user_id' }))
+      }).rejects.toThrow('JOIN is not supported')
     })
   })
 
   describe('CAST calls', () => {
-    it('should handle CAST to INTEGER in SELECT', () => {
+    it('should handle CAST to INTEGER in SELECT', async () => {
       const data = [
         { id: 1, age: '30' },
         { id: 2, age: '25' },
         { id: 3, age: '35' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT CAST(age AS INTEGER) as age_int FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT CAST(age AS INTEGER) as age_int FROM data' }))
       expect(result).toHaveLength(3)
       expect(result[0].age_int).toBe(30)
       expect(result[1].age_int).toBe(25)
       expect(result[2].age_int).toBe(35)
     })
 
-    it('should handle CAST in WHERE clause', () => {
+    it('should handle CAST in WHERE clause', async () => {
       const data = [
         { id: 1, age: '30' },
         { id: 2, age: '25' },
         { id: 3, age: '35' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE CAST(age AS INTEGER) > 28' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE CAST(age AS INTEGER) > 28' }))
       expect(result).toHaveLength(2)
       expect(result[0].id).toBe(1)
       expect(result[1].id).toBe(3)
     })
 
-    it('should handle CAST in HAVING clause', () => {
+    it('should handle CAST in HAVING clause', async () => {
       const data = [
         { city: 'NYC', count: 5 },
         { city: 'NYC', count: 3 },
         { city: 'LA', count: 10 },
         { city: 'SF', count: 2 },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { data },
         query: 'SELECT city, SUM(count) as total FROM data GROUP BY city HAVING total > CAST(\'5\' AS INTEGER)',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.city).sort()).toEqual(['LA', 'NYC'])
     })
   })
 
   describe('edge cases', () => {
-    it('should handle negative select', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT -age as neg_age FROM users' })
+    it('should handle negative select', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT -age as neg_age FROM users' }))
       expect(result).toHaveLength(5)
       expect(result[0].neg_age).toBe(-30)
     })
 
-    it('should handle negative where', () => {
+    it('should handle negative where', async () => {
       const data = [
         { id: 1, value: -10 },
         { id: 2, value: 5 },
         { id: 3, value: -3 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT value as neg_value FROM data WHERE -value > 8' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT value as neg_value FROM data WHERE -value > 8' }))
       expect(result).toHaveLength(1)
       expect(result[0].neg_value).toBe(-10)
     })
 
-    it('should handle rows with different keys', () => {
+    it('should handle rows with different keys', async () => {
       const users = [
         { id: 1, name: 'Alice' },
         { id: 2, email: 'bob@example.com' },
         { id: 3, name: 'Charlie', email: 'charlie@example.com' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users' }))
       expect(result).toEqual(users)
     })
 
-    it('should handle string comparisons lexicographically', () => {
+    it('should handle string comparisons lexicographically', async () => {
       const data = [
         { id: 1, value: '10' },
         { id: 2, value: '5' },
         { id: 3, value: '20' },
       ]
       // Lexicographic comparison: '5' > '2' and '20' > '2' are both true
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value > \'2\'' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value > \'2\'' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.value).sort()).toEqual(['20', '5'])
     })
 
-    it('should handle boolean values correctly', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE active' })
+    it('should handle boolean values correctly', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE active' }))
       expect(result).toHaveLength(4)
     })
 
-    it('should handle falsy values in WHERE clause', () => {
+    it('should handle falsy values in WHERE clause', async () => {
       const data = [
         { id: 1, value: 0 },
         { id: 2, value: 1 },
         { id: 3, value: false },
         { id: 4, value: true },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value' }))
       expect(result).toHaveLength(2)
       expect(result.every(r => r.value)).toBe(true)
     })
 
-    it('should handle empty string in comparisons', () => {
+    it('should handle empty string in comparisons', async () => {
       const data = [
         { id: 1, value: '' },
         { id: 2, value: 'hello' },
         { id: 3, value: null },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value = \'\'' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value = \'\'' }))
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe(1)
     })
 
-    it('should handle special characters in strings', () => {
+    it('should handle special characters in strings', async () => {
       const users = [
         { id: 1, name: 'O\'Brien' },
         { id: 2, name: 'Smith' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name = \'O\'\'Brien\'' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name = \'O\'\'Brien\'' }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('O\'Brien')
     })
 
-    it('should handle mixed types in ORDER BY', () => {
+    it('should handle mixed types in ORDER BY', async () => {
       const data = [
         { id: 1, value: 10 },
         { id: 2, value: '5' },
         { id: 3, value: 20 },
         { id: 4, value: '15' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data ORDER BY value' }))
       // Should sort lexicographically for mixed types
       expect(result[0].value).toBe(10)
     })
 
-    it('should handle very long column names', () => {
+    it('should handle very long column names', async () => {
       const data = [{ id: 1, very_long_column_name_that_exceeds_normal_limits: 'value' }]
-      const result = executeSql({ tables: { data }, query: 'SELECT very_long_column_name_that_exceeds_normal_limits FROM data' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT very_long_column_name_that_exceeds_normal_limits FROM data' }))
       expect(result[0].very_long_column_name_that_exceeds_normal_limits).toBe('value')
     })
 
-    it('should handle column names with spaces using double quotes', () => {
+    it('should handle column names with spaces using double quotes', async () => {
       const users = [
         { id: 1, 'first name': 'Alice', 'last name': 'Smith', age: 30 },
         { id: 2, 'first name': 'Bob', 'last name': 'Jones', age: 25 },
         { id: 3, 'first name': 'Charlie', 'last name': 'Brown', age: 35 },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT "first name", "last name", age FROM users WHERE age > 25' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT "first name", "last name", age FROM users WHERE age > 25' }))
       expect(result).toHaveLength(2)
       expect(result[0]).toEqual({ 'first name': 'Alice', 'last name': 'Smith', age: 30 })
       expect(result[1]).toEqual({ 'first name': 'Charlie', 'last name': 'Brown', age: 35 })
     })
 
-    it('should handle column names with spaces in ORDER BY', () => {
+    it('should handle column names with spaces in ORDER BY', async () => {
       const users = [
         { id: 1, 'full name': 'Charlie', score: 85 },
         { id: 2, 'full name': 'Alice', score: 95 },
         { id: 3, 'full name': 'Bob', score: 90 },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT "full name", score FROM users ORDER BY "full name"' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT "full name", score FROM users ORDER BY "full name"' }))
       expect(result).toHaveLength(3)
       expect(result[0]['full name']).toBe('Alice')
       expect(result[1]['full name']).toBe('Bob')
       expect(result[2]['full name']).toBe('Charlie')
     })
 
-    it('should handle column names with spaces in aggregates', () => {
+    it('should handle column names with spaces in aggregates', async () => {
       const data = [
         { id: 1, 'product name': 'Widget', 'total sales': 100 },
         { id: 2, 'product name': 'Gadget', 'total sales': 200 },
         { id: 3, 'product name': 'Widget', 'total sales': 150 },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT "product name", SUM("total sales") AS total FROM data GROUP BY "product name"' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT "product name", SUM("total sales") AS total FROM data GROUP BY "product name"' }))
       expect(result).toHaveLength(2)
       const widget = result.find(r => r['product name'] === 'Widget')
       expect(widget?.total).toBe(250)
@@ -343,16 +364,16 @@ describe('executeSql', () => {
   })
 
   describe('CASE expressions', () => {
-    it('should handle searched CASE expression', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, CASE WHEN age >= 30 THEN \'senior\' ELSE \'junior\' END AS category FROM users' })
+    it('should handle searched CASE expression', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name, CASE WHEN age >= 30 THEN \'senior\' ELSE \'junior\' END AS category FROM users' }))
       expect(result).toHaveLength(5)
       expect(result[0]).toEqual({ name: 'Alice', category: 'senior' })
       expect(result[1]).toEqual({ name: 'Bob', category: 'junior' })
       expect(result[2]).toEqual({ name: 'Charlie', category: 'senior' })
     })
 
-    it('should handle simple CASE expression', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name, CASE city WHEN \'NYC\' THEN \'New York\' WHEN \'LA\' THEN \'Los Angeles\' END AS city_full FROM users' })
+    it('should handle simple CASE expression', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name, CASE city WHEN \'NYC\' THEN \'New York\' WHEN \'LA\' THEN \'Los Angeles\' END AS city_full FROM users' }))
       expect(result).toHaveLength(5)
       expect(result[0]).toEqual({ name: 'Alice', city_full: 'New York' })
       expect(result[1]).toEqual({ name: 'Bob', city_full: 'Los Angeles' })
@@ -360,8 +381,8 @@ describe('executeSql', () => {
   })
 
   describe('subqueries', () => {
-    it('should support subquery in FROM clause', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT name FROM (SELECT * FROM users WHERE age > 25) AS u' })
+    it('should support subquery in FROM clause', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT name FROM (SELECT * FROM users WHERE age > 25) AS u' }))
       expect(result).toHaveLength(4)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie', 'Diana', 'Eve'])
     })

--- a/test/execute/execute.where.test.js
+++ b/test/execute/execute.where.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { executeSql } from '../../src/execute/execute.js'
+import { collect, executeSql } from '../../src/index.js'
 
 describe('executeSql', () => {
   const users = [
@@ -11,117 +11,117 @@ describe('executeSql', () => {
   ]
 
   describe('WHERE clause', () => {
-    it('should filter with equality', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name = \'Alice\'' })
+    it('should filter with equality', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name = \'Alice\'' }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Alice')
     })
 
-    it('should filter with comparison operators', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age > 30' })
+    it('should filter with comparison operators', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age > 30' }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Charlie')
     })
 
-    it('should filter with AND', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE city = \'NYC\' AND age = 30' })
+    it('should filter with AND', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE city = \'NYC\' AND age = 30' }))
       expect(result).toHaveLength(2)
       expect(result.every(u => u.city === 'NYC' && u.age === 30)).toBe(true)
     })
 
-    it('should filter with OR', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age < 26 OR age > 33' })
+    it('should filter with OR', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age < 26 OR age > 33' }))
       expect(result).toHaveLength(2)
       expect(result.map(u => u.name).sort()).toEqual(['Bob', 'Charlie'])
     })
 
-    it('should handle complex WHERE with parentheses', () => {
-      const result = executeSql({ tables: { users }, query: `
+    it('should handle complex WHERE with parentheses', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: `
         SELECT * FROM users
         WHERE (age < 28 OR age > 32) AND city = 'NYC'
-      ` })
+      ` }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Charlie')
     })
 
-    it('should handle OR precedence without parentheses', () => {
-      const result = executeSql({ tables: { users }, query: `
+    it('should handle OR precedence without parentheses', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: `
         SELECT * FROM users
         WHERE city = 'NYC' AND age = 30 OR city = 'LA'
-      ` })
+      ` }))
       // Should be: (city = 'NYC' AND age = 30) OR (city = 'LA')
       expect(result).toHaveLength(4)
     })
 
-    it('should filter with NOT', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE NOT active' })
+    it('should filter with NOT', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE NOT active' }))
       expect(result).toHaveLength(1)
       expect(result[0].name).toBe('Charlie')
     })
 
-    it('should handle inequality operators', () => {
-      const result1 = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age != 30' })
+    it('should handle inequality operators', async () => {
+      const result1 = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age != 30' }))
       expect(result1).toHaveLength(3)
 
-      const result2 = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age <> 30' })
+      const result2 = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age <> 30' }))
       expect(result2).toHaveLength(3)
     })
 
-    it('should handle <= and >= operators', () => {
-      const result1 = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age <= 28' })
+    it('should handle <= and >= operators', async () => {
+      const result1 = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age <= 28' }))
       expect(result1).toHaveLength(2)
 
-      const result2 = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age >= 30' })
+      const result2 = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age >= 30' }))
       expect(result2).toHaveLength(3)
     })
 
-    it('should handle literal values in WHERE', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE active = TRUE' })
+    it('should handle literal values in WHERE', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE active = TRUE' }))
       expect(result).toHaveLength(4)
     })
 
-    it('should handle IS NULL', () => {
+    it('should handle IS NULL', async () => {
       const users = [
         { id: 1, name: 'Alice', email: 'alice@example.com' },
         { id: 2, name: 'Bob', email: null },
         { id: 3, name: 'Charlie', email: null },
         { id: 4, name: 'Diana', email: 'diana@example.com' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE email IS NULL' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE email IS NULL' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Charlie'])
     })
 
-    it('should handle IS NOT NULL', () => {
+    it('should handle IS NOT NULL', async () => {
       const users = [
         { id: 1, name: 'Alice', email: 'alice@example.com' },
         { id: 2, name: 'Bob', email: null },
         { id: 3, name: 'Charlie', email: null },
         { id: 4, name: 'Diana', email: 'diana@example.com' },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE email IS NOT NULL',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Diana'])
     })
 
-    it('should handle IS NULL with undefined values', () => {
+    it('should handle IS NULL with undefined values', async () => {
       const users = [
         { id: 1, name: 'Alice' },
         { id: 2, name: 'Bob', email: 'bob@example.com' },
         { id: 3, name: 'Charlie' },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE email IS NULL',
-      })
+      }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie'])
     })
 
-    it('should handle IS NULL/IS NOT NULL with AND/OR', () => {
+    it('should handle IS NULL/IS NOT NULL with AND/OR', async () => {
       const users = [
         { id: 1, name: 'Alice', email: 'alice@example.com', phone: '123' },
         { id: 2, name: 'Bob', email: null, phone: '456' },
@@ -129,121 +129,121 @@ describe('executeSql', () => {
         { id: 4, name: 'Diana', email: 'diana@example.com', phone: null },
       ]
 
-      const result1 = executeSql({
+      const result1 = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE email IS NULL AND phone IS NOT NULL',
-      })
+      }))
       expect(result1).toHaveLength(1)
       expect(result1[0].name).toBe('Bob')
 
-      const result2 = executeSql({
+      const result2 = await collect(executeSql({
         tables: { users },
         query: 'SELECT * FROM users WHERE email IS NULL OR phone IS NULL',
-      })
+      }))
       expect(result2).toHaveLength(3)
       expect(result2.map(r => r.name).sort()).toEqual(['Bob', 'Charlie', 'Diana'])
     })
 
-    it('should NOT match NULL with equality', () => {
+    it('should NOT match NULL with equality', async () => {
       const data = [
         { id: 1, value: null },
         { id: 2, value: 0 },
         { id: 3, value: false },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value = NULL' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE value = NULL' }))
       expect(result).toHaveLength(0) // NULL comparisons should return false
     })
 
-    it('should filter with LIKE', () => {
+    it('should filter with LIKE', async () => {
       const users = [
         { id: 1, name: 'Alice' },
         { id: 2, name: 'Bob' },
         { id: 3, name: 'Charlie' },
         { id: 4, name: 'Diana' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name LIKE \'%li%\'' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name LIKE \'%li%\'' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie'])
     })
 
-    it('should filter with LIKE using underscore wildcard', () => {
+    it('should filter with LIKE using underscore wildcard', async () => {
       const data = [
         { id: 1, code: 'A123' },
         { id: 2, code: 'B456' },
         { id: 3, code: 'A1X3' },
         { id: 4, code: 'A12' },
       ]
-      const result = executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE code LIKE \'A1_3\'' })
+      const result = await collect(executeSql({ tables: { data }, query: 'SELECT * FROM data WHERE code LIKE \'A1_3\'' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.code).sort()).toEqual(['A123', 'A1X3'])
     })
 
-    it('should filter with LIKE combining % and _ wildcards', () => {
+    it('should filter with LIKE combining % and _ wildcards', async () => {
       const users = [
         { id: 1, email: 'alice@example.com' },
         { id: 2, email: 'bob@test.com' },
         { id: 3, email: 'charlie@example.org' },
         { id: 4, email: 'diana@example.com' },
       ]
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE email LIKE \'_____@example.___\'' })
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE email LIKE \'_____@example.___\'' }))
       expect(result).toHaveLength(2)
       expect(result.map(r => r.email).sort()).toEqual(['alice@example.com', 'diana@example.com'])
     })
 
-    it('should filter with IN value list', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name IN (\'Alice\', \'Charlie\', \'Eve\')' })
+    it('should filter with IN value list', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name IN (\'Alice\', \'Charlie\', \'Eve\')' }))
       expect(result).toHaveLength(3)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie', 'Eve'])
     })
 
-    it('should filter with IN value list of numbers', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age IN (25, 28, 30)' })
+    it('should filter with IN value list of numbers', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE age IN (25, 28, 30)' }))
       expect(result).toHaveLength(4)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Bob', 'Diana', 'Eve'])
     })
 
-    it('should filter with NOT IN value list', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name NOT IN (\'Alice\', \'Bob\')' })
+    it('should filter with NOT IN value list', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name NOT IN (\'Alice\', \'Bob\')' }))
       expect(result).toHaveLength(3)
       expect(result.map(r => r.name).sort()).toEqual(['Charlie', 'Diana', 'Eve'])
     })
 
-    it('should handle IN with empty result', () => {
-      const result = executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name IN (\'Zara\', \'Xander\')' })
+    it('should handle IN with empty result', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name IN (\'Zara\', \'Xander\')' }))
       expect(result).toHaveLength(0)
     })
 
-    it('should filter with IN subquery', () => {
+    it('should filter with IN subquery', async () => {
       const orders = [
         { id: 1, user_id: 1, amount: 100 },
         { id: 2, user_id: 2, amount: 200 },
         { id: 3, user_id: 3, amount: 150 },
         { id: 4, user_id: 1, amount: 50 },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { orders, users },
         query: 'SELECT * FROM orders WHERE user_id IN (SELECT id FROM users WHERE active = TRUE)',
-      })
+      }))
       // Users 1 and 2 are active, so orders 1, 2, 4 match
       expect(result).toHaveLength(3)
     })
 
-    it('should filter with NOT IN subquery', () => {
+    it('should filter with NOT IN subquery', async () => {
       const orders = [
         { id: 1, user_id: 1, amount: 100 },
         { id: 2, user_id: 2, amount: 200 },
         { id: 3, user_id: 3, amount: 150 },
         { id: 4, user_id: 1, amount: 50 },
       ]
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { orders, users },
         query: 'SELECT * FROM orders WHERE user_id NOT IN (SELECT id FROM users WHERE active = FALSE)',
-      })
+      }))
       // Users 3, 4, 5 are inactive, so orders with user_id 1, 2 remain (orders 1, 2, 4)
       expect(result).toHaveLength(3)
     })
 
-    it('should filter with EXISTS subquery (non-correlated)', () => {
+    it('should filter with EXISTS subquery (non-correlated)', async () => {
       const orders = [
         { id: 1, user_id: 1, amount: 100 },
         { id: 2, user_id: 2, amount: 200 },
@@ -251,14 +251,14 @@ describe('executeSql', () => {
         { id: 4, user_id: 1, amount: 50 },
       ]
       // Non-correlated EXISTS - returns all rows if subquery has results
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { orders, users },
         query: 'SELECT * FROM orders WHERE EXISTS (SELECT * FROM users WHERE active = TRUE)',
-      })
+      }))
       expect(result).toHaveLength(4) // all orders since there are active users
     })
 
-    it('should filter with NOT EXISTS subquery (non-correlated)', () => {
+    it('should filter with NOT EXISTS subquery (non-correlated)', async () => {
       const orders = [
         { id: 1, user_id: 1, amount: 100 },
         { id: 2, user_id: 2, amount: 200 },
@@ -266,10 +266,10 @@ describe('executeSql', () => {
         { id: 4, user_id: 1, amount: 50 },
       ]
       // Non-correlated NOT EXISTS - returns no rows if subquery has results
-      const result = executeSql({
+      const result = await collect(executeSql({
         tables: { orders, users },
         query: 'SELECT * FROM orders WHERE NOT EXISTS (SELECT * FROM users WHERE active = TRUE)',
-      })
+      }))
       expect(result).toHaveLength(0) // no orders since there are active users
     })
   })


### PR DESCRIPTION
# AsyncGenerator for Everything

Changes `executeSql` from synchronous to async streaming results back using AsyncGenerator.

 - `executeSql` now returns `AsyncGenerator<Record<string, any>>`
 - all functions throughout the execution engine refactored to be async
 - DataSource replaced with AsyncDataSource
 - Unified several codepaths to be all streaming
 - export `collect` helper function to gather results

This is exciting! It will enable all sorts of interesting cases where we want to stream rows back, not wait for a query to be fully loaded first. Way better for user experience if done right.
