### PR TITLE
Scan must return whether filters and offsets were applied

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ export type {
   ParseSqlOptions,
   QueryPlan,
   ScanOptions,
+  ScanResults,
   SelectStatement,
   SqlPrimitive,
   Token,

--- a/test/execute/execute.cte.test.js
+++ b/test/execute/execute.cte.test.js
@@ -206,15 +206,21 @@ describe('CTE execution', () => {
 
       // Create a custom data source that tracks execution
       const trackingSource = {
-        async *scan() {
+        scan() {
           executionCount++
-          for (const user of users) {
-            yield {
-              columns: Object.keys(user),
-              cells: Object.fromEntries(
-                Object.entries(user).map(([k, v]) => [k, () => Promise.resolve(v)])
-              ),
-            }
+          return {
+            rows: (async function* () {
+              for (const user of users) {
+                yield {
+                  columns: Object.keys(user),
+                  cells: Object.fromEntries(
+                    Object.entries(user).map(([k, v]) => [k, () => Promise.resolve(v)])
+                  ),
+                }
+              }
+            })(),
+            appliedWhere: false,
+            appliedLimitOffset: false,
           }
         },
       }

--- a/test/execute/execute.subquery.test.js
+++ b/test/execute/execute.subquery.test.js
@@ -84,6 +84,14 @@ describe('subqueries', () => {
       expect(result).toHaveLength(2)
       expect(result.map(r => r.name).sort()).toEqual(['Alice', 'Charlie'])
     })
+
+    it('should apply OFFSET for derived table with LIMIT', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: 'SELECT id FROM (SELECT * FROM users ORDER BY id) AS u LIMIT 1 OFFSET 1',
+      }))
+      expect(result).toEqual([{ id: 2 }])
+    })
   })
 
   describe('IN subquery', () => {

--- a/test/plan/plan.test.js
+++ b/test/plan/plan.test.js
@@ -74,53 +74,32 @@ describe('queryPlan', () => {
   })
 
   describe('WHERE clause', () => {
-    it('should add FilterNode for WHERE clause', () => {
+    it('should pass WHERE as hint without Filter node', () => {
       const plan = queryPlan(parseSql({ query: 'SELECT * FROM users WHERE age > 21' }))
       expect(plan).toEqual({
         type: 'Project',
         columns: [{ kind: 'star' }],
         child: {
-          type: 'Filter',
-          condition: {
-            type: 'binary',
-            op: '>',
-            left: {
-              type: 'identifier',
-              name: 'age',
-              positionStart: 26,
-              positionEnd: 29,
-            },
-            right: {
-              type: 'literal',
-              value: 21,
-              positionStart: 32,
-              positionEnd: 34,
-            },
-            positionStart: 26,
-            positionEnd: 34,
-          },
-          child: {
-            type: 'Scan',
-            table: 'users',
-            hints: {
-              where: {
-                type: 'binary',
-                op: '>',
-                left: {
-                  type: 'identifier',
-                  name: 'age',
-                  positionStart: 26,
-                  positionEnd: 29,
-                },
-                right: {
-                  type: 'literal',
-                  value: 21,
-                  positionStart: 32,
-                  positionEnd: 34,
-                },
+          type: 'Scan',
+          table: 'users',
+          hints: {
+            where: {
+              type: 'binary',
+              op: '>',
+              left: {
+                type: 'identifier',
+                name: 'age',
                 positionStart: 26,
+                positionEnd: 29,
+              },
+              right: {
+                type: 'literal',
+                value: 21,
+                positionStart: 32,
                 positionEnd: 34,
               },
+              positionStart: 26,
+              positionEnd: 34,
             },
           },
         },
@@ -227,41 +206,32 @@ describe('queryPlan', () => {
   })
 
   describe('LIMIT/OFFSET', () => {
-    it('should add LimitNode for LIMIT', () => {
+    it('should delegate LIMIT to scan hints without LimitNode', () => {
       const plan = queryPlan(parseSql({ query: 'SELECT * FROM users LIMIT 10' }))
       expect(plan).toEqual({
-        type: 'Limit',
-        limit: 10,
+        type: 'Project',
+        columns: [{ kind: 'star' }],
         child: {
-          type: 'Project',
-          columns: [{ kind: 'star' }],
-          child: {
-            type: 'Scan',
-            table: 'users',
-            hints: {
-              limit: 10,
-            },
+          type: 'Scan',
+          table: 'users',
+          hints: {
+            limit: 10,
           },
         },
       })
     })
 
-    it('should add LimitNode for OFFSET', () => {
+    it('should delegate offset and limit to scan hints without LimitNode', () => {
       const plan = queryPlan(parseSql({ query: 'SELECT * FROM users LIMIT 10 OFFSET 5' }))
       expect(plan).toEqual({
-        type: 'Limit',
-        limit: 10,
-        offset: 5,
+        type: 'Project',
+        columns: [{ kind: 'star' }],
         child: {
-          type: 'Project',
-          columns: [{ kind: 'star' }],
-          child: {
-            type: 'Scan',
-            table: 'users',
-            hints: {
-              limit: 10,
-              offset: 5,
-            },
+          type: 'Scan',
+          table: 'users',
+          hints: {
+            limit: 10,
+            offset: 5,
           },
         },
       })
@@ -580,48 +550,27 @@ describe('queryPlan', () => {
               },
             ],
             child: {
-              type: 'Filter',
-              condition: {
-                type: 'binary',
-                op: '>',
-                left: {
-                  type: 'identifier',
-                  name: 'age',
-                  positionStart: 43,
-                  positionEnd: 46,
-                },
-                right: {
-                  type: 'literal',
-                  value: 21,
-                  positionStart: 49,
-                  positionEnd: 51,
-                },
-                positionStart: 43,
-                positionEnd: 51,
-              },
-              child: {
-                type: 'Scan',
-                table: 'users',
-                hints: {
-                  columns: ['id', 'age'],
-                  where: {
-                    type: 'binary',
-                    op: '>',
-                    left: {
-                      type: 'identifier',
-                      name: 'age',
-                      positionStart: 43,
-                      positionEnd: 46,
-                    },
-                    right: {
-                      type: 'literal',
-                      value: 21,
-                      positionStart: 49,
-                      positionEnd: 51,
-                    },
+              type: 'Scan',
+              table: 'users',
+              hints: {
+                columns: ['id', 'age'],
+                where: {
+                  type: 'binary',
+                  op: '>',
+                  left: {
+                    type: 'identifier',
+                    name: 'age',
                     positionStart: 43,
+                    positionEnd: 46,
+                  },
+                  right: {
+                    type: 'literal',
+                    value: 21,
+                    positionStart: 49,
                     positionEnd: 51,
                   },
+                  positionStart: 43,
+                  positionEnd: 51,
                 },
               },
             },
@@ -665,48 +614,27 @@ describe('queryPlan', () => {
               },
             ],
             child: {
-              type: 'Filter',
-              condition: {
-                type: 'binary',
-                op: '>',
-                left: {
-                  type: 'identifier',
-                  name: 'age',
-                  positionStart: 29,
-                  positionEnd: 32,
-                },
-                right: {
-                  type: 'literal',
-                  value: 21,
-                  positionStart: 35,
-                  positionEnd: 37,
-                },
-                positionStart: 29,
-                positionEnd: 37,
-              },
-              child: {
-                type: 'Scan',
-                table: 'users',
-                hints: {
-                  columns: ['name', 'age'],
-                  where: {
-                    type: 'binary',
-                    op: '>',
-                    left: {
-                      type: 'identifier',
-                      name: 'age',
-                      positionStart: 29,
-                      positionEnd: 32,
-                    },
-                    right: {
-                      type: 'literal',
-                      value: 21,
-                      positionStart: 35,
-                      positionEnd: 37,
-                    },
+              type: 'Scan',
+              table: 'users',
+              hints: {
+                columns: ['name', 'age'],
+                where: {
+                  type: 'binary',
+                  op: '>',
+                  left: {
+                    type: 'identifier',
+                    name: 'age',
                     positionStart: 29,
+                    positionEnd: 32,
+                  },
+                  right: {
+                    type: 'literal',
+                    value: 21,
+                    positionStart: 35,
                     positionEnd: 37,
                   },
+                  positionStart: 29,
+                  positionEnd: 37,
                 },
               },
             },


### PR DESCRIPTION
Changes `AsyncDataSource.scan()` to return a `ScanResults` object (`{ rows, appliedWhere, appliedLimitOffset }`) instead of a bare `AsyncIterable<AsyncRow>`. This lets the engine know which query hints the data source actually applied, so it can correctly apply WHERE filtering and OFFSET skipping and LIMIT when the source didn't handle them.

Key changes:
 - New `ScanResults` type with rows, `appliedWhere`, and `appliedLimitOffset` flags
 - Engine applies WHERE/OFFSET/LIMIT itself when the data source reports it didn't
 - Query planner avoids redundant `Filter` and `Limit` plan nodes when scan handles them
 - `memorySource` applies offset/limit at scan time when no WHERE clause is present
 - Validates that sources don't apply offset without also applying where
 - README documents the custom data source interface
