### PR TITLE
Optimize COUNT(*)

### DIFF
--- a/src/backend/dataSource.js
+++ b/src/backend/dataSource.js
@@ -25,6 +25,7 @@ function asyncRow(obj) {
  */
 export function memorySource(data) {
   return {
+    numRows: data.length,
     scan({ where, limit, offset, signal }) {
       // Only apply offset and limit if no where clause
       const start = !where ? offset ?? 0 : 0

--- a/src/plan/types.d.ts
+++ b/src/plan/types.d.ts
@@ -1,7 +1,8 @@
-import { ExprNode, JoinType, OrderByItem, ScanOptions, SelectColumn } from '../types.js'
+import { DerivedColumn, ExprNode, JoinType, OrderByItem, ScanOptions, SelectColumn } from '../types.js'
 
 export type QueryPlan =
   | ScanNode
+  | CountNode
   | FilterNode
   | ProjectNode
   | SortNode
@@ -18,6 +19,13 @@ export interface ScanNode {
   type: 'Scan'
   table: string
   hints: ScanOptions
+}
+
+// Count node for COUNT(*) optimization
+export interface CountNode {
+  type: 'Count'
+  table: string
+  columns: DerivedColumn[]
 }
 
 // Single-child nodes

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,7 @@ export type Row = Record<string, SqlPrimitive>[]
  * Async data source for streaming SQL execution.
  */
 export interface AsyncDataSource {
+  numRows?: number
   scan(options: ScanOptions): ScanResults
 }
 

--- a/test/execute/scan.test.js
+++ b/test/execute/scan.test.js
@@ -6,10 +6,10 @@ import { collect, executeSql } from '../../src/index.js'
  */
 
 describe('scan hints', () => {
-  it('should not pass * as a column hint for COUNT(*)', async () => {
-    const hints = await captureHints('SELECT COUNT(*) FROM data')
+  it('should not pass * as a column hint for SUM(*)', async () => {
+    const hints = await captureHints('SELECT SUM(amount) FROM data')
     expect(hints.columns).not.toContain('*')
-    expect(hints.columns).toEqual([])
+    expect(hints.columns).toEqual(['amount'])
   })
 
   it('should pass column hints for COUNT(column)', async () => {

--- a/test/plan/plan.test.js
+++ b/test/plan/plan.test.js
@@ -284,10 +284,11 @@ describe('planSql', () => {
       })
     })
 
-    it('should add ScalarAggregateNode for aggregate without GROUP BY', () => {
+    it('should add CountNode for COUNT(*) without GROUP BY', () => {
       const plan = planSql({ query: 'SELECT COUNT(*) FROM users' })
       expect(plan).toEqual({
-        type: 'ScalarAggregate',
+        type: 'Count',
+        table: 'users',
         columns: [
           {
             kind: 'derived',
@@ -307,14 +308,17 @@ describe('planSql', () => {
             },
           },
         ],
-        child: {
-          type: 'Scan',
-          table: 'users',
-          hints: {
-            columns: [],
-          },
-        },
       })
+    })
+
+    it('should add ScalarAggregateNode for COUNT(*) with WHERE', () => {
+      const plan = planSql({ query: 'SELECT COUNT(*) FROM users WHERE age > 30' })
+      expect(plan.type).toBe('ScalarAggregate')
+    })
+
+    it('should add ScalarAggregateNode for non-COUNT(*) aggregate', () => {
+      const plan = planSql({ query: 'SELECT SUM(age) FROM users' })
+      expect(plan.type).toBe('ScalarAggregate')
     })
   })
 


### PR DESCRIPTION
Optimize `SELECT COUNT(*) FROM table`:
- Add optional `AsyncDataSource.numRows`
- Add `CountNode` to `QueryPlan`

This provides a massive speedup if the data source knows the row numbers in advance.

```
COUNT(*) benchmark: 1,000,000 rows, 50 iterations

With numRows:  0.039 ms  avg
Without numRows: 216.222 ms  avg

Speedup: 5568.1x
```