### PR TITLE
Correlated subqueries

### DIFF
--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -2,7 +2,8 @@ import { memorySource } from '../backend/dataSource.js'
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { parseSql } from '../parse/parse.js'
-import { planSql } from '../plan/plan.js'
+import { planSql, planStatement } from '../plan/plan.js'
+import { fromAlias } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
@@ -34,7 +35,8 @@ export function executeSql({ tables, query, functions, signal }) {
     }
   }
 
-  const context = { tables: normalizedTables, functions, signal }
+  const scope = statementScope(parsed)
+  const context = { tables: normalizedTables, functions, signal, scope }
   const plan = planSql({ query: parsed, functions, tables: normalizedTables })
   return executePlan({ plan, context })
 }
@@ -45,11 +47,26 @@ export function executeSql({ tables, query, functions, signal }) {
  * @param {Object} options
  * @param {Statement} options.query
  * @param {ExecuteContext} options.context
+ * @param {string[]} [options.outerScope] - outer query aliases for correlated subqueries
  * @returns {QueryResults}
  */
-export function executeStatement({ query, context }) {
-  const plan = planSql({ query, functions: context.functions, tables: context.tables })
-  return executePlan({ plan, context })
+export function executeStatement({ query, context, outerScope }) {
+  const plan = planStatement({ stmt: query, tables: context.tables, outerScope })
+  // Compute this query's scope (FROM alias + JOIN aliases) for nested correlated subqueries
+  const scope = statementScope(query)
+  return executePlan({ plan, context: scope ? { ...context, scope } : context })
+}
+
+/**
+ * Extracts the table aliases from a statement's FROM and JOIN clauses.
+ *
+ * @param {Statement} stmt
+ * @returns {string[] | undefined}
+ */
+function statementScope(stmt) {
+  if (stmt.type === 'with') return statementScope(stmt.query)
+  if (stmt.type === 'compound') return undefined
+  return [fromAlias(stmt.from), ...stmt.joins.map(j => j.alias ?? j.table)]
 }
 
 /**

--- a/src/expression/evaluate.js
+++ b/src/expression/evaluate.js
@@ -39,6 +39,10 @@ export async function evaluateExpr({ node, row, rowIndex, rows, context }) {
       if (qualified in row.cells) {
         return row.cells[qualified]()
       }
+      // Check outer row for correlated subquery references
+      if (context.outerRow && context.outerAliases?.has(node.prefix) && node.name in context.outerRow.cells) {
+        return context.outerRow.cells[node.name]()
+      }
       // Fall back to just the column part
       if (node.name in row.cells) {
         return row.cells[node.name]()
@@ -66,7 +70,11 @@ export async function evaluateExpr({ node, row, rowIndex, rows, context }) {
 
   // Scalar subquery - returns a single value
   if (node.type === 'subquery') {
-    const gen = executeStatement({ query: node.subquery, context }).rows()
+    const outerScope = context.scope
+    const subContext = outerScope
+      ? { ...context, outerRow: row, outerAliases: new Set(outerScope) }
+      : context
+    const gen = executeStatement({ query: node.subquery, context: subContext, outerScope }).rows()
     const { value } = await gen.next()
     gen.return(undefined)
     if (!value) return null

--- a/src/plan/columns.js
+++ b/src/plan/columns.js
@@ -163,7 +163,54 @@ function collectColumnsFromExpr(expr, columns, aliases) {
       collectColumnsFromExpr(expr.elseResult, columns, aliases)
     }
   }
-  // No columns: count(*), literal, interval, exists, not exists, subquery
+  // Subqueries: collect prefixed identifiers for correlated column detection.
+  // Only prefixed identifiers are collected because correlated outer references
+  // are always qualified (e.g. users.id, a.session_id). Unprefixed identifiers
+  // from the inner query would incorrectly be attributed to the outer table.
+  if (expr.type === 'subquery' || expr.type === 'in' || expr.type === 'exists' || expr.type === 'not exists') {
+    if (expr.type === 'in') {
+      collectColumnsFromExpr(expr.expr, columns, aliases)
+    }
+    const sub = expr.subquery
+    if (sub) {
+      /** @type {IdentifierNode[]} */
+      const inner = []
+      collectColumnsFromStatement(sub, inner)
+      for (const id of inner) {
+        if (id.prefix) columns.push(id)
+      }
+    }
+  }
+  // No columns: count(*), literal, interval
+}
+
+/**
+ * Collects identifiers from a subquery statement for correlated column detection.
+ *
+ * @param {Statement} stmt
+ * @param {IdentifierNode[]} columns
+ */
+function collectColumnsFromStatement(stmt, columns) {
+  if (stmt.type === 'compound') {
+    collectColumnsFromStatement(stmt.left, columns)
+    collectColumnsFromStatement(stmt.right, columns)
+    return
+  }
+  if (stmt.type === 'with') {
+    collectColumnsFromStatement(stmt.query, columns)
+    return
+  }
+  for (const col of stmt.columns) {
+    if (col.type === 'derived') collectColumnsFromExpr(col.expr, columns)
+  }
+  collectColumnsFromExpr(stmt.where, columns)
+  if (stmt.from?.type === 'subquery') {
+    collectColumnsFromStatement(stmt.from.query, columns)
+  }
+  for (const join of stmt.joins) collectColumnsFromExpr(join.on, columns)
+  for (const expr of stmt.groupBy) collectColumnsFromExpr(expr, columns)
+  collectColumnsFromExpr(stmt.having, columns)
+  for (const item of stmt.orderBy) collectColumnsFromExpr(item.expr, columns)
 }
 
 /**

--- a/src/plan/plan.js
+++ b/src/plan/plan.js
@@ -32,9 +32,10 @@ export function planSql({ query, functions, tables }) {
  * @param {Map<string, string[]>} [options.cteColumns]
  * @param {Record<string, AsyncDataSource>} [options.tables]
  * @param {IdentifierNode[]} [options.parentColumns] - columns needed by the parent query (for subquery pushdown)
+ * @param {string[]} [options.outerScope] - aliases from an outer query (for correlated subqueries)
  * @returns {QueryPlan}
  */
-function planStatement({ stmt, ctePlans, cteColumns, tables, parentColumns }) {
+export function planStatement({ stmt, ctePlans, cteColumns, tables, parentColumns, outerScope }) {
   if (stmt.type === 'with') {
     // Build CTE plans in order (each CTE can reference preceding CTEs)
     ctePlans ??= new Map()
@@ -44,12 +45,12 @@ function planStatement({ stmt, ctePlans, cteColumns, tables, parentColumns }) {
       ctePlans.set(cte.name.toLowerCase(), ctePlan)
       cteColumns.set(cte.name.toLowerCase(), inferStatementColumns({ stmt: cte.query, cteColumns, tables }))
     }
-    return planStatement({ stmt: stmt.query, ctePlans, cteColumns, tables, parentColumns })
+    return planStatement({ stmt: stmt.query, ctePlans, cteColumns, tables, parentColumns, outerScope })
   }
   if (stmt.type === 'compound') {
     return planSetOperation({ compound: stmt, ctePlans, cteColumns, tables })
   }
-  return planSelect({ select: stmt, ctePlans, cteColumns, tables, parentColumns })
+  return planSelect({ select: stmt, ctePlans, cteColumns, tables, parentColumns, outerScope })
 }
 
 /**
@@ -100,9 +101,10 @@ function planSetOperation({ compound, ctePlans, cteColumns, tables }) {
  * @param {Map<string, string[]>} [options.cteColumns]
  * @param {Record<string, AsyncDataSource>} [options.tables]
  * @param {IdentifierNode[]} [options.parentColumns] - columns needed by the parent query (for subquery pushdown)
+ * @param {string[]} [options.outerScope] - aliases from an outer query (for correlated subqueries)
  * @returns {QueryPlan}
  */
-function planSelect({ select, ctePlans, cteColumns, tables, parentColumns }) {
+function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outerScope }) {
   // Check for aggregation
   const hasAggregate = select.columns.some(col =>
     col.type === 'derived' && findAggregate(col.expr)
@@ -114,7 +116,8 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns }) {
   const sourceAlias = fromAlias(select.from)
 
   // Resolve aliases (and validate qualified references)
-  const scopeTables = Object.fromEntries([sourceAlias, ...select.joins.map(j => j.alias ?? j.table)].map(a => [a, true]))
+  // Include outerScope aliases so correlated references pass validation
+  const scopeTables = Object.fromEntries([sourceAlias, ...select.joins.map(j => j.alias ?? j.table), ...outerScope ?? []].map(a => [a, true]))
   /** @type {Map<string, ExprNode>} */
   const aliases = new Map()
   const columns = select.columns.map(col => {
@@ -168,7 +171,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns }) {
 
   // Start with the data source (FROM clause)
   /** @type {QueryPlan} */
-  let plan = planFrom({ select, ctePlans, cteColumns, hints, tables })
+  let plan = planFrom({ select, ctePlans, cteColumns, hints, tables, outerScope })
 
   // Add JOINs
   if (select.joins.length) {
@@ -260,9 +263,10 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns }) {
  * @param {Map<string, string[]>} [options.cteColumns]
  * @param {ScanOptions} options.hints
  * @param {Record<string, AsyncDataSource>} [options.tables]
+ * @param {string[]} [options.outerScope]
  * @returns {QueryPlan}
  */
-function planFrom({ select, ctePlans, cteColumns, hints, tables }) {
+function planFrom({ select, ctePlans, cteColumns, hints, tables, outerScope }) {
   if (select.from.type === 'table') {
     const ctePlan = ctePlans?.get(select.from.table.toLowerCase())
     if (ctePlan) {
@@ -276,6 +280,7 @@ function planFrom({ select, ctePlans, cteColumns, hints, tables }) {
       ctePlans,
       cteColumns,
       tables,
+      outerScope,
       parentColumns: hints.columns?.map(name => ({ type: 'identifier', name, positionStart: 0, positionEnd: 0 })),
     })
     // Validate that requested columns exist in subquery output

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -40,6 +40,12 @@ export interface ExecuteContext {
   tables: Record<string, AsyncDataSource>
   functions?: Record<string, UserDefinedFunction>
   signal?: AbortSignal
+  // current query's FROM + JOIN aliases (e.g. ['a', 'b'])
+  scope?: string[]
+  // the enclosing query's current row, for resolving correlated references
+  outerRow?: AsyncRow
+  // aliases from the enclosing query that are valid correlated references
+  outerAliases?: Set<string>
 }
 
 // AsyncRow represents a row with async cell values

--- a/test/execute/execute.subquery.test.js
+++ b/test/execute/execute.subquery.test.js
@@ -457,23 +457,192 @@ describe('subqueries', () => {
       expect(charlie?.max_age).toBe(35)
     })
 
-    // it('should handle correlated scalar subquery', async () => {
-    //   const result = await collect(executeSql({
-    //     tables: { users, orders },
-    //     query: `
-    //       SELECT
-    //         name,
-    //         (SELECT SUM(amount) FROM orders WHERE user_id = users.id) AS total_orders
-    //       FROM users
-    //     `,
-    //   }))
-    //   expect(result).toHaveLength(3)
-    //   const alice = result.find(r => r.name === 'Alice')
-    //   const bob = result.find(r => r.name === 'Bob')
-    //   const charlie = result.find(r => r.name === 'Charlie')
-    //   expect(alice?.total_orders).toBe(250)
-    //   expect(bob?.total_orders).toBe(200)
-    //   expect(charlie?.total_orders).toBeNull()
-    // })
+    it('should handle correlated scalar subquery', async () => {
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT
+            name,
+            (SELECT SUM(amount) FROM orders WHERE user_id = users.id) AS total_orders
+          FROM users
+        `,
+      }))
+      expect(result).toHaveLength(3)
+      const alice = result.find(r => r.name === 'Alice')
+      const bob = result.find(r => r.name === 'Bob')
+      const charlie = result.find(r => r.name === 'Charlie')
+      expect(alice?.total_orders).toBe(250)
+      expect(bob?.total_orders).toBe(200)
+      expect(charlie?.total_orders).toBeNull()
+    })
+
+    it('should handle correlated scalar subquery with ORDER BY and LIMIT', async () => {
+      const messages = [
+        { session_id: 1, role: 'user', content: 'hello', timestamp: 1 },
+        { session_id: 1, role: 'assistant', content: 'hi there', timestamp: 2 },
+        { session_id: 1, role: 'user', content: 'how are you', timestamp: 3 },
+        { session_id: 1, role: 'assistant', content: 'doing well', timestamp: 4 },
+        { session_id: 2, role: 'user', content: 'hey', timestamp: 5 },
+        { session_id: 2, role: 'assistant', content: 'howdy', timestamp: 6 },
+      ]
+      const result = await collect(executeSql({
+        tables: { messages },
+        query: `
+          SELECT
+            a.session_id,
+            a.timestamp,
+            a.content AS assistant_content,
+            (SELECT u.content FROM messages u
+             WHERE u.session_id = a.session_id
+               AND u.role = 'user'
+               AND u.timestamp < a.timestamp
+             ORDER BY u.timestamp DESC
+             LIMIT 1) AS prior_user
+          FROM messages a
+          WHERE a.role = 'assistant'
+          ORDER BY a.timestamp
+        `,
+      }))
+      expect(result).toEqual([
+        { session_id: 1, timestamp: 2, assistant_content: 'hi there', prior_user: 'hello' },
+        { session_id: 1, timestamp: 4, assistant_content: 'doing well', prior_user: 'how are you' },
+        { session_id: 2, timestamp: 6, assistant_content: 'howdy', prior_user: 'hey' },
+      ])
+    })
+
+    it('should return null when correlated subquery matches no rows', async () => {
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT name, (SELECT amount FROM orders WHERE user_id = users.id AND amount > 9999) AS big_order
+          FROM users
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', big_order: null },
+        { name: 'Bob', big_order: null },
+        { name: 'Charlie', big_order: null },
+      ])
+    })
+
+    it('should handle multiple correlated subqueries in same SELECT', async () => {
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT
+            name,
+            (SELECT COUNT(*) FROM orders WHERE user_id = users.id) AS order_count,
+            (SELECT MAX(amount) FROM orders WHERE user_id = users.id) AS max_order
+          FROM users
+          ORDER BY name
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', order_count: 2, max_order: 150 },
+        { name: 'Bob', order_count: 1, max_order: 200 },
+        { name: 'Charlie', order_count: 0, max_order: null },
+      ])
+    })
+
+    it('should disambiguate inner vs outer columns with same name', async () => {
+      // Both tables have 'id' — outer users.id vs inner orders.id
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT name, (SELECT MIN(id) FROM orders WHERE user_id = users.id) AS first_order_id
+          FROM users
+          ORDER BY name
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', first_order_id: 1 },
+        { name: 'Bob', first_order_id: 2 },
+        { name: 'Charlie', first_order_id: null },
+      ])
+    })
+
+    it('should handle correlated subquery with aliased outer table', async () => {
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT u.name, (SELECT SUM(amount) FROM orders o WHERE o.user_id = u.id) AS total
+          FROM users u
+          ORDER BY u.name
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', total: 250 },
+        { name: 'Bob', total: 200 },
+        { name: 'Charlie', total: null },
+      ])
+    })
+
+    it('should handle correlated subquery referencing outer WHERE-filtered rows', async () => {
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT name, (SELECT SUM(amount) FROM orders WHERE user_id = users.id) AS total
+          FROM users
+          WHERE active = TRUE
+          ORDER BY name
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', total: 250 },
+        { name: 'Bob', total: 200 },
+      ])
+    })
+
+    it('should handle correlated subquery with self-join pattern', async () => {
+      // Find users whose age is above the average of all other users
+      const result = await collect(executeSql({
+        tables: { users },
+        query: `
+          SELECT u.name, u.age,
+            (SELECT AVG(age) FROM users WHERE id != u.id) AS others_avg
+          FROM users u
+          ORDER BY u.name
+        `,
+      }))
+      expect(result).toHaveLength(3)
+      const alice = result.find(r => r.name === 'Alice')
+      expect(alice?.others_avg).toBe(30) // avg(25, 35)
+    })
+
+    it('should handle correlated subquery in expression context', async () => {
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT
+            name,
+            age - (SELECT AVG(age) FROM users) AS age_diff
+          FROM users
+          ORDER BY name
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', age_diff: 0 },
+        { name: 'Bob', age_diff: -5 },
+        { name: 'Charlie', age_diff: 5 },
+      ])
+    })
+
+    it('should handle correlated subquery nested inside FROM subquery', async () => {
+      // The correlated ref (users.id) is inside a FROM-clause subquery
+      const result = await collect(executeSql({
+        tables: { users, orders },
+        query: `
+          SELECT name,
+            (SELECT max_amt FROM (SELECT MAX(amount) AS max_amt FROM orders WHERE user_id = users.id) AS sub) AS biggest
+          FROM users
+          ORDER BY name
+        `,
+      }))
+      expect(result).toEqual([
+        { name: 'Alice', biggest: 150 },
+        { name: 'Bob', biggest: 200 },
+        { name: 'Charlie', biggest: null },
+      ])
+    })
   })
 })


### PR DESCRIPTION
Fix correlated subqueries. This really helps to avoid the need for window functions.
