### PR TITLE
Execute cleanup

### DIFF
--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -265,33 +265,30 @@ function executeScan(plan, context) {
 function executeCount(plan, context) {
   const { tables, signal } = context
   const table = validateTable({ ...plan, tables })
+  const columns = plan.columns.map(col => col.alias ?? derivedAlias(col.expr))
 
   return {
-    columns: plan.columns.map(col => col.alias ?? derivedAlias(col.expr)),
+    columns,
     numRows: 1,
     maxRows: 1,
     async *rows() {
       // Use source numRows if available
-      let count = table.numRows
-      if (count === undefined) {
+      const countPromise = table.numRows !== undefined ? Promise.resolve(table.numRows) : (async () => {
         // Fall back to counting rows via scan
-        count = 0
+        let count = 0
         const { rows } = table.scan({ signal })
         // eslint-disable-next-line no-unused-vars
         for await (const _ of rows()) {
           if (signal?.aborted) return
           count++
         }
-      }
+        return count
+      })()
 
-      /** @type {string[]} */
-      const columns = []
       /** @type {AsyncCells} */
       const cells = {}
-      for (const col of plan.columns) {
-        const alias = col.alias ?? derivedAlias(col.expr)
-        columns.push(alias)
-        cells[alias] = () => Promise.resolve(count)
+      for (const alias of columns) {
+        cells[alias] = () => countPromise
       }
       yield { columns, cells }
     },
@@ -366,21 +363,19 @@ async function* filterRows(rows, condition, context, limit) {
  * @param {AbortSignal} [signal]
  * @yields {AsyncRow}
  */
-async function* limitRows(rows, limit, offset, signal) {
-  const skip = offset ?? 0
-  const max = limit ?? Infinity
-  if (max <= 0) return
+async function* limitRows(rows, limit = Infinity, offset = 0, signal) {
+  if (limit <= 0) return
   let skipped = 0
   let yielded = 0
   for await (const row of rows) {
     if (signal?.aborted) return
-    if (skipped < skip) {
+    if (skipped < offset) {
       skipped++
       continue
     }
     yield row
     yielded++
-    if (yielded >= max) return
+    if (yielded >= limit) return
   }
 }
 

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -404,30 +404,28 @@ function executeFilter(plan, context) {
  */
 function executeProject(plan, context) {
   const child = executePlan({ plan: plan.child, context })
+  const columns = selectColumnNames(plan.columns, child.columns)
 
-  // Pre-compute column names for derived columns (avoids per-row derivedAlias calls)
   const hasStar = plan.columns.some(col => col.type === 'star')
+  const allStar = hasStar && plan.columns.every(col => col.type === 'star')
 
-  /** @type {string[] | undefined} */
-  let staticColumns
   /** @type {{ alias: string, sourceName: string }[] | undefined} */
   let identifierMap
   if (!hasStar) {
     const derived = /** @type {DerivedColumn[]} */ (plan.columns)
-    staticColumns = derived.map(col => col.alias ?? derivedAlias(col.expr))
     const allIdentifiers = derived.every(col =>
       col.expr.type === 'identifier' && !col.expr.prefix
     )
     if (allIdentifiers) {
       identifierMap = derived.map((col, i) => ({
-        alias: staticColumns[i],
+        alias: columns[i],
         sourceName: /** @type {IdentifierNode} */ (col.expr).name,
       }))
     }
   }
 
   return {
-    columns: selectColumnNames(plan.columns, child.columns),
+    columns,
     numRows: child.numRows,
     maxRows: child.maxRows,
     async *rows() {
@@ -457,31 +455,36 @@ function executeProject(plan, context) {
             cells[alias] = row.cells[sourceName]
             if (resolved && source) resolved[alias] = source[sourceName]
           }
-          yield { columns: staticColumns, cells, resolved }
+          yield { columns, cells, resolved }
           continue
         }
 
         const currentRowIndex = rowIndex
 
-        /** @type {string[]} */
-        const columns = staticColumns ?? []
         /** @type {AsyncCells} */
         const cells = {}
+        // Only safe to propagate resolved when every output column comes from
+        // the star branch — derived expressions evaluate lazily and can't be
+        // pre-materialized here, and a partial resolved would make
+        // collect()/downstream identifier fast paths read undefined.
+        const source = allStar ? row.resolved : undefined
+        /** @type {Record<string, SqlPrimitive> | undefined} */
+        const resolved = source ? {} : undefined
 
-        for (let i = 0; i < plan.columns.length; i++) {
-          const col = plan.columns[i]
+        let colIdx = 0
+        for (const col of plan.columns) {
           if (col.type === 'star') {
             const prefix = col.table ? `${col.table}.` : undefined
             for (const key of row.columns) {
               if (prefix && !key.startsWith(prefix)) continue
               const dotIndex = key.indexOf('.')
               const outputKey = dotIndex >= 0 ? key.substring(dotIndex + 1) : key
-              columns.push(outputKey)
               cells[outputKey] = row.cells[key]
+              if (resolved && source) resolved[outputKey] = source[key]
+              colIdx++
             }
           } else {
-            const alias = staticColumns ? staticColumns[i] : col.alias ?? derivedAlias(col.expr)
-            if (!staticColumns) columns.push(alias)
+            const alias = columns[colIdx++]
             cells[alias] = () => evaluateExpr({
               node: col.expr,
               row,
@@ -491,7 +494,7 @@ function executeProject(plan, context) {
           }
         }
 
-        yield { columns, cells }
+        yield { columns, cells, resolved }
       }
     },
   }

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -406,23 +406,9 @@ function executeProject(plan, context) {
   const child = executePlan({ plan: plan.child, context })
   const columns = selectColumnNames(plan.columns, child.columns)
 
-  const hasStar = plan.columns.some(col => col.type === 'star')
-  const allStar = hasStar && plan.columns.every(col => col.type === 'star')
-
-  /** @type {{ alias: string, sourceName: string }[] | undefined} */
-  let identifierMap
-  if (!hasStar) {
-    const derived = /** @type {DerivedColumn[]} */ (plan.columns)
-    const allIdentifiers = derived.every(col =>
-      col.expr.type === 'identifier' && !col.expr.prefix
-    )
-    if (allIdentifiers) {
-      identifierMap = derived.map((col, i) => ({
-        alias: columns[i],
-        sourceName: /** @type {IdentifierNode} */ (col.expr).name,
-      }))
-    }
-  }
+  const resolveable = plan.columns.every(col =>
+    col.type === 'star' || col.type === 'derived' && col.expr.type === 'identifier'
+  )
 
   return {
     columns,
@@ -430,35 +416,10 @@ function executeProject(plan, context) {
     maxRows: child.maxRows,
     async *rows() {
       let rowIndex = 0
-      let identifierMapValidated = false
 
       for await (const row of child.rows()) {
         if (context.signal?.aborted) return
         rowIndex++
-
-        // Validate identifier fast path on first row (may fail for JOINs with prefixed columns)
-        if (identifierMap && !identifierMapValidated) {
-          identifierMapValidated = true
-          if (!identifierMap.every(m => m.sourceName in row.cells)) {
-            identifierMap = undefined
-          }
-        }
-
-        // Fast path: all columns are simple identifier references
-        if (identifierMap) {
-          /** @type {AsyncCells} */
-          const cells = {}
-          const source = row.resolved
-          /** @type {Record<string, SqlPrimitive> | undefined} */
-          const resolved = source ? {} : undefined
-          for (const { alias, sourceName } of identifierMap) {
-            cells[alias] = row.cells[sourceName]
-            if (resolved && source) resolved[alias] = source[sourceName]
-          }
-          yield { columns, cells, resolved }
-          continue
-        }
-
         const currentRowIndex = rowIndex
 
         /** @type {AsyncCells} */
@@ -467,7 +428,7 @@ function executeProject(plan, context) {
         // the star branch — derived expressions evaluate lazily and can't be
         // pre-materialized here, and a partial resolved would make
         // collect()/downstream identifier fast paths read undefined.
-        const source = allStar ? row.resolved : undefined
+        const source = resolveable ? row.resolved : undefined
         /** @type {Record<string, SqlPrimitive> | undefined} */
         const resolved = source ? {} : undefined
 
@@ -483,6 +444,15 @@ function executeProject(plan, context) {
               if (resolved && source) resolved[outputKey] = source[key]
               colIdx++
             }
+          } else if (col.expr.type === 'identifier') {
+            // Common case: simple identifier. Avoid evaluateExpr overhead by
+            // directly mapping to the child's cell, relying on the planner to
+            // have normalized the identifier to match the child's column layout.
+            const id = col.expr
+            const sourceName = id.prefix ? `${id.prefix}.${id.name}` : id.name
+            cells[columns[colIdx]] = row.cells[sourceName]
+            if (resolved && source) resolved[columns[colIdx]] = source[sourceName]
+            colIdx++
           } else {
             const alias = columns[colIdx++]
             cells[alias] = () => evaluateExpr({

--- a/src/plan/columns.js
+++ b/src/plan/columns.js
@@ -281,7 +281,7 @@ export function inferStatementColumns({ stmt, cteColumns, tables }) {
  * @param {Record<string, AsyncDataSource>} [options.tables]
  * @returns {string[]}
  */
-function inferSelectSourceColumns({ select, cteColumns, tables }) {
+export function inferSelectSourceColumns({ select, cteColumns, tables }) {
   if (select.from.type === 'subquery') {
     return inferStatementColumns({ stmt: select.from.query, cteColumns, tables })
   }

--- a/src/plan/plan.js
+++ b/src/plan/plan.js
@@ -3,7 +3,7 @@ import { parseSql } from '../parse/parse.js'
 import { findAggregate } from '../validation/aggregates.js'
 import { ColumnNotFoundError, TableNotFoundError } from '../validation/tables.js'
 import { validateNoIdentifiers, validateScan, validateTableRefs } from '../validation/tables.js'
-import { extractColumns, fromAlias, inferStatementColumns, tableFunctionColumnName } from './columns.js'
+import { extractColumns, fromAlias, inferSelectSourceColumns, inferStatementColumns, tableFunctionColumnName } from './columns.js'
 
 /**
  * @import { AsyncDataSource, ExprNode, DerivedColumn, IdentifierNode, JoinClause, PlanSqlOptions, ScanOptions, SelectColumn, SelectStatement, SetOperationStatement, Statement } from '../types.js'
@@ -242,6 +242,15 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
           col.type === 'star' || parentColumns.some(id => id.name === (col.alias ?? derivedAlias(col.expr)))
         )
       }
+      // Normalize identifiers to match the child's cell-key layout, so the
+      // Project executor can look up cells by exact name instead of relying
+      // on the evaluator's suffix-search fallback.
+      const sourceColumns = inferSelectSourceColumns({ select, cteColumns, tables })
+      projectColumns = projectColumns.map(col =>
+        col.type === 'derived'
+          ? { ...col, expr: normalizeIdentifiers(col.expr, sourceColumns) }
+          : col
+      )
       plan = { type: 'Project', columns: projectColumns, child: plan }
     }
 
@@ -416,6 +425,69 @@ function resolveAliases(node, aliases) {
     return { ...node, caseExpr, whenClauses, elseResult }
   }
   // literal, interval, subquery, in, exists: no identifiers to resolve
+  return node
+}
+
+/**
+ * Rewrites identifiers so their `prefix`/`name` pair matches a cell key that
+ * will actually exist in the child row. A join child yields cells keyed as
+ * `alias.column`; a plain scan or CTE yields bare `column`. Applying this at
+ * plan time lets the Project fast path use exact lookups and keeps the
+ * evaluator from having to suffix-search row.columns at runtime.
+ *
+ * @param {ExprNode} node
+ * @param {string[]} sourceColumns
+ * @returns {ExprNode}
+ */
+function normalizeIdentifiers(node, sourceColumns) {
+  if (!node) return node
+  if (node.type === 'identifier') {
+    const current = node.prefix ? `${node.prefix}.${node.name}` : node.name
+    if (sourceColumns.includes(current)) return node
+    if (node.prefix) {
+      if (sourceColumns.includes(node.name)) return { ...node, prefix: undefined }
+      return node
+    }
+    const suffix = '.' + node.name
+    const matches = sourceColumns.filter(c => c.endsWith(suffix))
+    if (matches.length === 1) {
+      return { ...node, prefix: matches[0].slice(0, matches[0].length - suffix.length) }
+    }
+    return node
+  }
+  if (node.type === 'unary') {
+    return { ...node, argument: normalizeIdentifiers(node.argument, sourceColumns) }
+  }
+  if (node.type === 'binary') {
+    return { ...node, left: normalizeIdentifiers(node.left, sourceColumns), right: normalizeIdentifiers(node.right, sourceColumns) }
+  }
+  if (node.type === 'function') {
+    return { ...node, args: node.args.map(arg => normalizeIdentifiers(arg, sourceColumns)) }
+  }
+  if (node.type === 'cast') {
+    return { ...node, expr: normalizeIdentifiers(node.expr, sourceColumns) }
+  }
+  if (node.type === 'in valuelist') {
+    return {
+      ...node,
+      expr: normalizeIdentifiers(node.expr, sourceColumns),
+      values: node.values.map(v => normalizeIdentifiers(v, sourceColumns)),
+    }
+  }
+  if (node.type === 'case') {
+    return {
+      ...node,
+      caseExpr: normalizeIdentifiers(node.caseExpr, sourceColumns),
+      whenClauses: node.whenClauses.map(w => ({
+        ...w,
+        condition: normalizeIdentifiers(w.condition, sourceColumns),
+        result: normalizeIdentifiers(w.result, sourceColumns),
+      })),
+      elseResult: normalizeIdentifiers(node.elseResult, sourceColumns),
+    }
+  }
+  // literal, interval, subquery, in, exists: leave unchanged (subquery bodies
+  // have their own source layout; correlated references must stay as-is).
   return node
 }
 


### PR DESCRIPTION
- Normalize `Project` identifiers at plan time so the executor can look up cells by exact key instead of suffix-searching at runtime.
- Collapse the `Project` fast path into a single loop: star + bare-identifier columns alias child cells directly (propagating `resolved` when safe), only real expressions go through `evaluateExpr`.
- `Count` now yields its output row immediately with a `countPromise` behind the cell, so consumers don't block on the scan fallback.
