### PR TITLE
Order by grouped aggregate

### DIFF
--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -1,7 +1,7 @@
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { executePlan, selectColumnNames } from './execute.js'
-import { keyify } from './utils.js'
+import { compareForTerm, keyify } from './utils.js'
 
 /**
  * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, QueryResults, SelectColumn, SqlPrimitive } from '../types.js'
@@ -51,6 +51,22 @@ function projectAggregateColumns(selectColumns, group, context) {
 }
 
 /**
+ * Builds the row visible to post-aggregation expressions such as HAVING and
+ * grouped ORDER BY: source group columns plus aggregate output aliases.
+ *
+ * @param {AsyncRow[]} group
+ * @param {AsyncRow} aggregateRow
+ * @returns {AsyncRow}
+ */
+function aggregateContextRow(group, aggregateRow) {
+  const baseRow = group[0] ?? { columns: [], cells: {} }
+  return {
+    columns: [...baseRow.columns, ...aggregateRow.columns],
+    cells: { ...baseRow.cells, ...aggregateRow.cells },
+  }
+}
+
+/**
  * Executes a hash aggregate operation (GROUP BY)
  *
  * @param {HashAggregateNode} plan
@@ -85,27 +101,49 @@ export function executeHashAggregate(plan, context) {
         group.push(row)
       }
 
-      // Yield one row per group
+      /** @type {{ row: AsyncRow, group: AsyncRow[], contextRow: AsyncRow, sortValues?: (SqlPrimitive | undefined)[] }[]} */
+      const aggregateRows = []
+
       for (const group of groups.values()) {
         const asyncRow = projectAggregateColumns(plan.columns, group, context)
+        const contextRow = aggregateContextRow(group, asyncRow)
 
         // Apply HAVING filter
         if (plan.having) {
-          /** @type {AsyncRow} */
-          const havingRow = {
-            columns: [...group[0].columns, ...asyncRow.columns],
-            cells: { ...group[0].cells, ...asyncRow.cells },
-          }
           const passes = await evaluateExpr({
             node: plan.having,
-            row: havingRow,
+            row: contextRow,
             rows: group,
             context,
           })
           if (!passes) continue
         }
 
-        yield asyncRow
+        aggregateRows.push({ row: asyncRow, group, contextRow })
+      }
+
+      if (plan.orderBy?.length) {
+        for (const aggregateRow of aggregateRows) {
+          aggregateRow.sortValues = await Promise.all(plan.orderBy.map(term =>
+            evaluateExpr({
+              node: term.expr,
+              row: aggregateRow.contextRow,
+              rows: aggregateRow.group,
+              context,
+            })
+          ))
+        }
+        aggregateRows.sort((a, b) => {
+          for (let i = 0; i < plan.orderBy.length; i++) {
+            const cmp = compareForTerm(a.sortValues?.[i], b.sortValues?.[i], plan.orderBy[i])
+            if (cmp !== 0) return cmp
+          }
+          return 0
+        })
+      }
+
+      for (const { row } of aggregateRows) {
+        yield row
       }
     },
   }

--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -1,7 +1,8 @@
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { executePlan, selectColumnNames } from './execute.js'
-import { compareForTerm, keyify } from './utils.js'
+import { sortEntriesByTerms } from './sort.js'
+import { keyify } from './utils.js'
 
 /**
  * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, QueryResults, SelectColumn, SqlPrimitive } from '../types.js'
@@ -101,7 +102,7 @@ export function executeHashAggregate(plan, context) {
         group.push(row)
       }
 
-      /** @type {{ row: AsyncRow, group: AsyncRow[], contextRow: AsyncRow, sortValues?: (SqlPrimitive | undefined)[] }[]} */
+      /** @type {{ row: AsyncRow, group: AsyncRow[], contextRow: AsyncRow }[]} */
       const aggregateRows = []
 
       for (const group of groups.values()) {
@@ -123,23 +124,16 @@ export function executeHashAggregate(plan, context) {
       }
 
       if (plan.orderBy?.length) {
-        for (const aggregateRow of aggregateRows) {
-          aggregateRow.sortValues = await Promise.all(plan.orderBy.map(term =>
-            evaluateExpr({
-              node: term.expr,
-              row: aggregateRow.contextRow,
-              rows: aggregateRow.group,
-              context,
-            })
-          ))
-        }
-        aggregateRows.sort((a, b) => {
-          for (let i = 0; i < plan.orderBy.length; i++) {
-            const cmp = compareForTerm(a.sortValues?.[i], b.sortValues?.[i], plan.orderBy[i])
-            if (cmp !== 0) return cmp
-          }
-          return 0
+        const sortedRows = await sortEntriesByTerms({
+          entries: aggregateRows.map((aggregateRow, idx) => ({
+            row: aggregateRow.contextRow,
+            rows: aggregateRow.group,
+            idx,
+          })),
+          orderBy: plan.orderBy,
+          context,
         })
+        aggregateRows.splice(0, aggregateRows.length, ...sortedRows.map(({ idx }) => aggregateRows[idx]))
       }
 
       for (const { row } of aggregateRows) {

--- a/src/execute/sort.js
+++ b/src/execute/sort.js
@@ -4,11 +4,116 @@ import { executePlan } from './execute.js'
 import { compareForTerm } from './utils.js'
 
 /**
- * @import { AsyncRow, ExecuteContext, QueryResults, SqlPrimitive } from '../types.js'
+ * @import { AsyncRow, ExecuteContext, OrderByItem, QueryResults, SqlPrimitive } from '../types.js'
  * @import { SortNode } from '../plan/types.js'
  */
 
 const MAX_CHUNK = 256
+
+/**
+ * @typedef {{
+ *   row: AsyncRow,
+ *   rows?: AsyncRow[],
+ * }} SortEntry
+ */
+
+/**
+ * Sorts rows by ORDER BY terms while evaluating async sort keys in concurrent
+ * chunks and delaying later terms until earlier terms tie.
+ *
+ * @template {SortEntry} T
+ * @param {{
+ *   entries: T[],
+ *   orderBy: OrderByItem[],
+ *   context: ExecuteContext,
+ *   cacheValues?: boolean,
+ * }} options
+ * @returns {Promise<T[]>}
+ */
+export async function sortEntriesByTerms({ entries, orderBy, context, cacheValues = false }) {
+  if (entries.length === 0) return []
+
+  /** @type {(SqlPrimitive | undefined)[][]} */
+  const evaluatedValues = entries.map(() => Array(orderBy.length))
+
+  /** @type {number[][]} */
+  let groups = [entries.map((_, i) => i)]
+
+  for (let orderByIdx = 0; orderByIdx < orderBy.length; orderByIdx++) {
+    const term = orderBy[orderByIdx]
+    /** @type {number[][]} */
+    const nextGroups = []
+
+    for (const group of groups) {
+      if (group.length <= 1) {
+        nextGroups.push(group)
+        continue
+      }
+
+      const alias = derivedAlias(term.expr)
+      /** @type {number[]} */
+      const missing = []
+      for (const idx of group) {
+        if (evaluatedValues[idx][orderByIdx] === undefined) missing.push(idx)
+      }
+      let chunkSize = 1
+      let start = 0
+      while (start < missing.length) {
+        if (context.signal?.aborted) return []
+        const chunk = missing.slice(start, start + chunkSize)
+        const values = await Promise.all(chunk.map(idx =>
+          evaluateExpr({
+            node: term.expr,
+            row: entries[idx].row,
+            rows: entries[idx].rows,
+            context,
+          })
+        ))
+        for (let i = 0; i < chunk.length; i++) {
+          const idx = chunk[i]
+          const value = values[i]
+          evaluatedValues[idx][orderByIdx] = value
+          if (cacheValues && !(alias in entries[idx].row.cells)) {
+            entries[idx].row.cells[alias] = () => Promise.resolve(value)
+          }
+        }
+        start += chunk.length
+        chunkSize = Math.min(chunkSize * 2, MAX_CHUNK)
+      }
+
+      group.sort((aIdx, bIdx) => {
+        const av = evaluatedValues[aIdx][orderByIdx]
+        const bv = evaluatedValues[bIdx][orderByIdx]
+        return compareForTerm(av, bv, term)
+      })
+
+      if (orderByIdx < orderBy.length - 1) {
+        /** @type {number[]} */
+        let currentSubGroup = [group[0]]
+        for (let i = 1; i < group.length; i++) {
+          const prevIdx = group[i - 1]
+          const currIdx = group[i]
+          const prevVal = evaluatedValues[prevIdx][orderByIdx]
+          const currVal = evaluatedValues[currIdx][orderByIdx]
+
+          if (compareForTerm(prevVal, currVal, term) === 0) {
+            currentSubGroup.push(currIdx)
+          } else {
+            nextGroups.push(currentSubGroup)
+            currentSubGroup = [currIdx]
+          }
+        }
+        nextGroups.push(currentSubGroup)
+      } else {
+        nextGroups.push(group)
+      }
+    }
+
+    groups = nextGroups
+  }
+
+  return groups.flat().map(idx => entries[idx])
+}
 
 /**
  * Executes a sort operation (ORDER BY)
@@ -32,92 +137,16 @@ export function executeSort(plan, context) {
         rows.push(row)
       }
 
-      if (rows.length === 0) return
-
-      // Multi-pass lazy sorting
-      /** @type {(SqlPrimitive | undefined)[][]} */
-      const evaluatedValues = rows.map(() => Array(plan.orderBy.length))
-
-      /** @type {number[][]} */
-      let groups = [rows.map((_, i) => i)]
-
-      for (let orderByIdx = 0; orderByIdx < plan.orderBy.length; orderByIdx++) {
-        const term = plan.orderBy[orderByIdx]
-        /** @type {number[][]} */
-        const nextGroups = []
-
-        for (const group of groups) {
-          if (group.length <= 1) {
-            nextGroups.push(group)
-            continue
-          }
-
-          // Evaluate this column for all rows in the group, in parallel
-          // chunks that double up to MAX_CHUNK so a slow UDF doesn't serialize.
-          // Cache each value back into the row so downstream projection can
-          // reuse it instead of re-invoking the expression.
-          const alias = derivedAlias(term.expr)
-          /** @type {number[]} */
-          const missing = []
-          for (const idx of group) {
-            if (evaluatedValues[idx][orderByIdx] === undefined) missing.push(idx)
-          }
-          let chunkSize = 1
-          let start = 0
-          while (start < missing.length) {
-            if (context.signal?.aborted) return
-            const chunk = missing.slice(start, start + chunkSize)
-            const values = await Promise.all(chunk.map(idx =>
-              evaluateExpr({ node: term.expr, row: rows[idx], context })
-            ))
-            for (let i = 0; i < chunk.length; i++) {
-              const idx = chunk[i]
-              const value = values[i]
-              evaluatedValues[idx][orderByIdx] = value
-              if (!(alias in rows[idx].cells)) {
-                rows[idx].cells[alias] = () => Promise.resolve(value)
-              }
-            }
-            start += chunk.length
-            chunkSize = Math.min(chunkSize * 2, MAX_CHUNK)
-          }
-
-          // Sort the group by this column
-          group.sort((aIdx, bIdx) => {
-            const av = evaluatedValues[aIdx][orderByIdx]
-            const bv = evaluatedValues[bIdx][orderByIdx]
-            return compareForTerm(av, bv, term)
-          })
-
-          // Split into sub-groups based on ties
-          if (orderByIdx < plan.orderBy.length - 1) {
-            /** @type {number[]} */
-            let currentSubGroup = [group[0]]
-            for (let i = 1; i < group.length; i++) {
-              const prevIdx = group[i - 1]
-              const currIdx = group[i]
-              const prevVal = evaluatedValues[prevIdx][orderByIdx]
-              const currVal = evaluatedValues[currIdx][orderByIdx]
-
-              if (compareForTerm(prevVal, currVal, term) === 0) {
-                currentSubGroup.push(currIdx)
-              } else {
-                nextGroups.push(currentSubGroup)
-                currentSubGroup = [currIdx]
-              }
-            }
-            nextGroups.push(currentSubGroup)
-          } else {
-            nextGroups.push(group)
-          }
-        }
-
-        groups = nextGroups
-      }
+      const sortedRows = await sortEntriesByTerms({
+        entries: rows.map(row => ({ row })),
+        orderBy: plan.orderBy,
+        context,
+        cacheValues: true,
+      })
 
       // Yield sorted rows
-      for (const idx of groups.flat()) {
-        yield rows[idx]
+      for (const { row } of sortedRows) {
+        yield row
       }
     },
   }

--- a/src/plan/plan.js
+++ b/src/plan/plan.js
@@ -7,7 +7,7 @@ import { validateNoIdentifiers, validateScan, validateTableRefs } from '../valid
 import { extractColumns, fromAlias, inferSelectSourceColumns, inferStatementColumns, tableFunctionColumnNames } from './columns.js'
 
 /**
- * @import { AsyncDataSource, ExprNode, DerivedColumn, IdentifierNode, JoinClause, PlanSqlOptions, ScanOptions, SelectColumn, SelectStatement, SetOperationStatement, Statement, WindowFunctionNode } from '../types.js'
+ * @import { AsyncDataSource, ExprNode, DerivedColumn, IdentifierNode, JoinClause, OrderByItem, PlanSqlOptions, ScanOptions, SelectColumn, SelectStatement, SetOperationStatement, Statement, WindowFunctionNode } from '../types.js'
  * @import { QueryPlan, WindowSpec } from './types.d.ts'
  */
 
@@ -177,6 +177,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
     }
     return col
   })
+  const orderBy = resolveOrderByAliases(select.orderBy, aliases)
 
   // Validate qualified references in other clauses
   validateTableRefs(select.where, scopeTables)
@@ -235,7 +236,16 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
       const groupBy = aliases.size > 0
         ? select.groupBy.map(expr => resolveAliases(expr, aliases))
         : select.groupBy
-      plan = { type: 'HashAggregate', groupBy, columns, having: select.having, child: plan }
+      /** @type {QueryPlan} */
+      const aggregatePlan = {
+        type: 'HashAggregate',
+        groupBy,
+        columns,
+        having: select.having,
+        child: plan,
+      }
+      if (orderBy.length) aggregatePlan.orderBy = orderBy
+      plan = aggregatePlan
     } else if (!select.having && !select.where && plan.type === 'Scan' && isOwnScan && isAllCountStar(select.columns)) {
       plan = { type: 'Count', table: plan.table, columns: select.columns }
     } else {
@@ -243,8 +253,8 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
     }
 
     // ORDER BY (after aggregation)
-    if (select.orderBy.length) {
-      plan = { type: 'Sort', orderBy: select.orderBy, child: plan }
+    if (orderBy.length && !select.groupBy.length) {
+      plan = { type: 'Sort', orderBy, child: plan }
     }
 
     // DISTINCT
@@ -267,10 +277,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
 
     // ORDER BY (before projection so it can access all columns)
     // Resolve SELECT aliases in ORDER BY expressions at plan time
-    if (select.orderBy.length) {
-      const orderBy = aliases.size > 0
-        ? select.orderBy.map(term => ({ ...term, expr: resolveAliases(term.expr, aliases) }))
-        : select.orderBy
+    if (orderBy.length) {
       plan = { type: 'Sort', orderBy, child: plan }
     }
 
@@ -470,6 +477,19 @@ function planJoin({ left, joins, leftTable, ctePlans, cteColumns, perTableColumn
 }
 
 /**
+ * Recursively replaces identifier nodes in ORDER BY terms that match SELECT
+ * aliases with their aliased expressions.
+ *
+ * @param {OrderByItem[]} orderBy
+ * @param {Map<string, ExprNode>} aliases
+ * @returns {OrderByItem[]}
+ */
+function resolveOrderByAliases(orderBy, aliases) {
+  if (!aliases.size) return orderBy
+  return orderBy.map(term => ({ ...term, expr: resolveAliases(term.expr, aliases) }))
+}
+
+/**
  * Recursively replaces identifier nodes that match SELECT aliases
  * with their aliased expressions.
  *
@@ -492,7 +512,8 @@ function resolveAliases(node, aliases) {
   }
   if (node.type === 'function') {
     const args = node.args.map(arg => resolveAliases(arg, aliases))
-    return { ...node, args }
+    if (!node.filter) return { ...node, args }
+    return { ...node, args, filter: resolveAliases(node.filter, aliases) }
   }
   if (node.type === 'cast') {
     return { ...node, expr: resolveAliases(node.expr, aliases) }

--- a/src/plan/types.d.ts
+++ b/src/plan/types.d.ts
@@ -67,6 +67,7 @@ export interface HashAggregateNode {
   type: 'HashAggregate'
   groupBy: ExprNode[]
   columns: SelectColumn[]
+  orderBy?: OrderByItem[]
   having?: ExprNode
   child: QueryPlan
 }

--- a/test/execute/execute.orderby.test.js
+++ b/test/execute/execute.orderby.test.js
@@ -248,9 +248,66 @@ describe('ORDER BY', () => {
       expect(result).toEqual([{ parity: 1, count: 2 }, { parity: 0, count: 2 }])
     })
 
-    it('throws on aggregate expression without alias', async () => {
-      await expect(() => collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY COUNT(*)' })))
-        .rejects.toThrow('Aggregate function COUNT is not available in this context')
+    it('should sort by SELECT alias nested inside aggregate ORDER BY expression', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: 'SELECT age AS a, COUNT(*) AS count FROM users GROUP BY a ORDER BY SUM(a)',
+      }))
+      expect(result).toEqual([
+        { a: 25, count: 1 },
+        { a: 28, count: 1 },
+        { a: 35, count: 1 },
+        { a: 30, count: 2 },
+      ])
+    })
+
+    it('should sort by aggregate expression not selected by alias', async () => {
+      const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) as cnt FROM users GROUP BY city ORDER BY COUNT(*)' }))
+      expect(result).toEqual([{ city: 'LA', cnt: 2 }, { city: 'NYC', cnt: 3 }])
+    })
+
+    it('should sort by an arithmetic expression containing aggregates', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: `
+          SELECT city, COUNT(*) AS cnt
+          FROM users
+          GROUP BY city
+          ORDER BY (SUM(CASE WHEN active THEN 1 ELSE 0 END) * 100.0 / COUNT(*)) DESC
+        `,
+      }))
+      // LA is 100% active (2/2); NYC is 67% active (2/3) — LA sorts first DESC.
+      expect(result[0].city).toBe('LA')
+      expect(result[1].city).toBe('NYC')
+    })
+
+    it('should sort by aggregate / aggregate ratio', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: `
+          SELECT city, COUNT(*) AS cnt
+          FROM users
+          GROUP BY city
+          ORDER BY SUM(age) / COUNT(*) DESC
+        `,
+      }))
+      // NYC avg age 31.67 (95/3); LA avg age 26.5 (53/2). NYC first DESC.
+      expect(result[0].city).toBe('NYC')
+      expect(result[1].city).toBe('LA')
+    })
+
+    it('should sort by an aggregate plus a constant', async () => {
+      const result = await collect(executeSql({
+        tables: { users },
+        query: `
+          SELECT city, COUNT(*) AS cnt
+          FROM users
+          GROUP BY city
+          ORDER BY (COUNT(*) + 0) DESC
+        `,
+      }))
+      expect(result[0].city).toBe('NYC')
+      expect(result[1].city).toBe('LA')
     })
   })
 

--- a/test/execute/execute.orderby.test.js
+++ b/test/execute/execute.orderby.test.js
@@ -309,6 +309,38 @@ describe('ORDER BY', () => {
       expect(result[0].city).toBe('NYC')
       expect(result[1].city).toBe('LA')
     })
+
+    it('should evaluate grouped sort-key UDF concurrently', async () => {
+      const data = Array.from({ length: 300 }, (_, i) => ({ g: 299 - i }))
+      let inFlight = 0
+      let peak = 0
+      /** @type {Record<string, UserDefinedFunction>} */
+      const functions = {
+        SLOW: {
+          async apply(x) {
+            inFlight++
+            peak = Math.max(peak, inFlight)
+            await new Promise(r => setTimeout(r, 1))
+            inFlight--
+            return x
+          },
+          arguments: { min: 1, max: 1 },
+        },
+      }
+      const result = await collect(executeSql({
+        tables: { data },
+        functions,
+        query: 'SELECT g, COUNT(*) AS cnt FROM data GROUP BY g ORDER BY SLOW(g) LIMIT 5',
+      }))
+      expect(result).toEqual([
+        { g: 0, cnt: 1 },
+        { g: 1, cnt: 1 },
+        { g: 2, cnt: 1 },
+        { g: 3, cnt: 1 },
+        { g: 4, cnt: 1 },
+      ])
+      expect(peak).toBeGreaterThan(10)
+    })
   })
 
   describe('NULLS FIRST and NULLS LAST', () => {

--- a/test/plan/plan.test.js
+++ b/test/plan/plan.test.js
@@ -687,93 +687,97 @@ describe('planSql', () => {
         type: 'Limit',
         limit: 10,
         child: {
-          type: 'Sort',
+          type: 'HashAggregate',
+          groupBy: [
+            {
+              type: 'identifier',
+              name: 'department',
+              positionStart: 55,
+              positionEnd: 65,
+            },
+          ],
+          columns: [
+            {
+              type: 'derived',
+              expr: {
+                type: 'identifier',
+                name: 'department',
+                positionStart: 7,
+                positionEnd: 17,
+              },
+              positionStart: 7,
+              positionEnd: 17,
+            },
+            {
+              type: 'derived',
+              expr: {
+                type: 'function',
+                funcName: 'COUNT',
+                args: [
+                  {
+                    type: 'star',
+                    positionStart: 25,
+                    positionEnd: 26,
+                  },
+                ],
+                positionStart: 19,
+                positionEnd: 27,
+              },
+              alias: 'cnt',
+              positionStart: 19,
+              positionEnd: 34,
+            },
+          ],
           orderBy: [
             {
               expr: {
-                type: 'identifier',
-                name: 'cnt',
-                positionStart: 95,
-                positionEnd: 98,
+                type: 'function',
+                funcName: 'COUNT',
+                args: [
+                  {
+                    type: 'star',
+                    positionStart: 25,
+                    positionEnd: 26,
+                  },
+                ],
+                positionStart: 19,
+                positionEnd: 27,
               },
               direction: 'ASC',
               positionStart: 0,
               positionEnd: 98,
             },
           ],
-          child: {
-            type: 'HashAggregate',
-            groupBy: [
-              {
-                type: 'identifier',
-                name: 'department',
-                positionStart: 55,
-                positionEnd: 65,
-              },
-            ],
-            columns: [
-              {
-                type: 'derived',
-                expr: {
-                  type: 'identifier',
-                  name: 'department',
-                  positionStart: 7,
-                  positionEnd: 17,
+          having: {
+            type: 'binary',
+            op: '>',
+            left: {
+              type: 'function',
+              funcName: 'COUNT',
+              args: [
+                {
+                  type: 'star',
+                  positionStart: 79,
+                  positionEnd: 80,
                 },
-                positionStart: 7,
-                positionEnd: 17,
-              },
-              {
-                type: 'derived',
-                expr: {
-                  type: 'function',
-                  funcName: 'COUNT',
-                  args: [
-                    {
-                      type: 'star',
-                      positionStart: 25,
-                      positionEnd: 26,
-                    },
-                  ],
-                  positionStart: 19,
-                  positionEnd: 27,
-                },
-                alias: 'cnt',
-                positionStart: 19,
-                positionEnd: 34,
-              },
-            ],
-            having: {
-              type: 'binary',
-              op: '>',
-              left: {
-                type: 'function',
-                funcName: 'COUNT',
-                args: [
-                  {
-                    type: 'star',
-                    positionStart: 79,
-                    positionEnd: 80,
-                  },
-                ],
-                positionStart: 73,
-                positionEnd: 81,
-              },
-              right: {
-                type: 'literal',
-                value: 5,
-                positionStart: 84,
-                positionEnd: 85,
-              },
+              ],
               positionStart: 73,
+              positionEnd: 81,
+            },
+            right: {
+              type: 'literal',
+              value: 5,
+              positionStart: 84,
               positionEnd: 85,
             },
-            child: {
-              type: 'Scan',
-              table: 'users',
-              hints: {
-                columns: ['department'],
-              },
+            positionStart: 73,
+            positionEnd: 85,
+          },
+          child: {
+            type: 'Scan',
+            table: 'users',
+            hints: {
+              columns: ['department'],
             },
           },
         },


### PR DESCRIPTION
- Extracted shared chunked `ORDER BY` evaluation into `sortEntriesByTerms()`.
- Reused that helper for grouped aggregate `ORDER BY` so async sort-key UDFs run concurrently instead of serially per group.
- Preserved aggregate-aware ordering context for expressions involving group columns and aggregate outputs.
- Added a regression test for `GROUP BY ... ORDER BY SLOW(g)` to assert concurrent sort-key evaluation.
