### PR TITLE
[codex] Fix grouped order by call stack overflow

### DIFF
--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -102,7 +102,7 @@ export function executeHashAggregate(plan, context) {
         group.push(row)
       }
 
-      /** @type {{ row: AsyncRow, group: AsyncRow[], contextRow: AsyncRow }[]} */
+      /** @type {{ row: AsyncRow, rows: AsyncRow[], outputRow: AsyncRow }[]} */
       const aggregateRows = []
 
       for (const group of groups.values()) {
@@ -120,24 +120,19 @@ export function executeHashAggregate(plan, context) {
           if (!passes) continue
         }
 
-        aggregateRows.push({ row: asyncRow, group, contextRow })
+        aggregateRows.push({ row: contextRow, rows: group, outputRow: asyncRow })
       }
 
-      if (plan.orderBy?.length) {
-        const sortedRows = await sortEntriesByTerms({
-          entries: aggregateRows.map((aggregateRow, idx) => ({
-            row: aggregateRow.contextRow,
-            rows: aggregateRow.group,
-            idx,
-          })),
+      const outputRows = plan.orderBy?.length
+        ? await sortEntriesByTerms({
+          entries: aggregateRows,
           orderBy: plan.orderBy,
           context,
         })
-        aggregateRows.splice(0, aggregateRows.length, ...sortedRows.map(({ idx }) => aggregateRows[idx]))
-      }
+        : aggregateRows
 
-      for (const { row } of aggregateRows) {
-        yield row
+      for (const { outputRow } of outputRows) {
+        yield outputRow
       }
     },
   }

--- a/test/execute/execute.orderby.test.js
+++ b/test/execute/execute.orderby.test.js
@@ -223,6 +223,16 @@ describe('ORDER BY', () => {
       expect(result[0].cnt).toBe(3)
     })
 
+    it('should sort many groups without overflowing the call stack', async () => {
+      const data = Array.from({ length: 200000 }, (_, i) => ({ g: i }))
+      const result = await collect(executeSql({
+        tables: { data },
+        query: 'SELECT g, COUNT(*) AS cnt FROM data GROUP BY g ORDER BY cnt DESC LIMIT 5',
+      }))
+      expect(result).toHaveLength(5)
+      expect(result.map(r => r.cnt)).toEqual([1, 1, 1, 1, 1])
+    })
+
     it('should sort by aggregate expression without alias', async () => {
       const result = await collect(executeSql({ tables: { users }, query: 'SELECT city, COUNT(*) FROM users GROUP BY city ORDER BY COUNT(*)' }))
       expect(result[0].city).toBe('LA')


### PR DESCRIPTION
## Summary
- avoid spreading all grouped aggregate rows into `Array.prototype.splice` after grouped `ORDER BY`
- reorder aggregate rows with bounded call arguments instead
- add a regression test covering many unique groups ordered by an aggregate alias

## Root cause
Grouped `ORDER BY` sorted aggregate rows and then called `aggregateRows.splice(0, aggregateRows.length, ...sortedRows.map(...))`. When the number of groups was large, the spread produced one function argument per group and could exceed the JavaScript call stack before any SQL result was returned.

## Validation
- `npm test -- test/execute/execute.orderby.test.js`
- `npm test`
- `npm run lint`
- from `/Users/phil/workspace/hyperparam`: `npm run repro:sql-callstack -- --mode=synthetic --rows=500000 --quiet`
- from `/Users/phil/workspace/hyperparam`: `npm run repro:sql-callstack -- --rows=500000 --out-limit=1 --quiet`