### PR TITLE
Execution budget + QueryBudgetExceededError for buffering operators

### DIFF
--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -7,7 +7,7 @@ import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, QueryResults, SelectColumn, SqlPrimitive } from '../types.js'
+ * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, ExecutionBudget, QueryResults, SelectColumn, SqlPrimitive } from '../types.js'
  * @import { HashAggregateNode, ScalarAggregateNode } from '../plan/types.js'
  */
 
@@ -264,7 +264,7 @@ export function executeScalarAggregate(plan, context) {
  * @param {ExecuteContext} context
  * @returns {(() => AsyncGenerator<AsyncRow>) | undefined}
  */
-function tryColumnScanAggregate(plan, { tables, signal }) {
+function tryColumnScanAggregate(plan, { tables, signal, budget }) {
   // No HAVING support in fast path
   if (plan.having) return
   // Child must be a direct table scan
@@ -295,7 +295,7 @@ function tryColumnScanAggregate(plan, { tables, signal }) {
 
     for (const spec of specs) {
       columns.push(spec.alias)
-      cells[spec.alias] = () => scanColumnAggregate({ table, spec, limit, offset, signal })
+      cells[spec.alias] = () => scanColumnAggregate({ table, spec, limit, offset, signal, budget })
     }
 
     yield { columns, cells }
@@ -335,19 +335,30 @@ function extractColumnAggSpec({ expr, alias }) {
  * @param {number} [options.limit]
  * @param {number} [options.offset]
  * @param {AbortSignal} [options.signal]
+ * @param {ExecutionBudget} [options.budget] - bounds the COUNT(DISTINCT) dedup set
  * @returns {Promise<SqlPrimitive>}
  */
-async function scanColumnAggregate({ table, spec, limit, offset, signal }) {
+async function scanColumnAggregate({ table, spec, limit, offset, signal, budget }) {
   const values = table.scanColumn({ column: spec.column, limit, offset, signal })
 
   if (spec.funcName === 'COUNT' && spec.distinct) {
+    // COUNT(DISTINCT) retains one dedup-set entry per distinct value — O(distinct
+    // rows), not O(1) — so even on the column-scan fast path it is a buffering
+    // operator and can OOM on a high-cardinality column. Charge each retained
+    // key into the budget and refuse over the ceiling (hypaware LLP 0056). The
+    // plain COUNT/SUM/MIN/MAX/AVG paths below hold O(1) state and stay immune.
+    const distinctBudget = new BufferBudget(budget, 'COUNT(DISTINCT)')
     const seen = new Set()
     for await (const chunk of values) {
       if (signal?.aborted) return
       for (let i = 0; i < chunk.length; i++) {
         const v = chunk[i]
         if (v == null) continue
-        seen.add(keyify(v))
+        const key = keyify(v)
+        if (!seen.has(key)) {
+          distinctBudget.addKey(key)
+          seen.add(key)
+        }
       }
     }
     return seen.size

--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -1,5 +1,6 @@
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
+import { BufferBudget } from './budget.js'
 import { executePlan, selectColumnNames } from './execute.js'
 import { sortEntriesByTerms } from './sort.js'
 import { keyify } from './utils.js'
@@ -84,6 +85,10 @@ export function executeHashAggregate(plan, context) {
     columns: selectColumnNames(plan.columns, child.columns),
     maxRows: child.maxRows,
     async *rows() {
+      // GROUP BY buffers the whole input to build groups; high-cardinality
+      // keys make this unbounded, so bound it with the execution budget and
+      // refuse over the ceiling rather than spill or truncate (hypaware LLP 0056).
+      const budget = new BufferBudget(context.budget, 'GROUP BY')
       // Collect all rows
       /** @type {AsyncRow[]} */
       const allRows = []
@@ -93,6 +98,7 @@ export function executeHashAggregate(plan, context) {
           await yieldToEventLoop()
           if (context.signal?.aborted) return
         }
+        budget.addRow(row)
         allRows.push(row)
       }
 
@@ -200,6 +206,10 @@ export function executeScalarAggregate(plan, context) {
     numRows: plan.having ? undefined : 1,
     maxRows: 1,
     async *rows() {
+      // Scalar-aggregate slow path: with no scanColumn fast path the whole
+      // input is collected into one group, so bound it with the execution
+      // budget and refuse over the ceiling rather than spill (hypaware LLP 0056).
+      const budget = new BufferBudget(context.budget, 'aggregate')
       // Collect all rows into single group
       /** @type {AsyncRow[]} */
       const group = []
@@ -209,6 +219,7 @@ export function executeScalarAggregate(plan, context) {
           await yieldToEventLoop()
           if (context.signal?.aborted) return
         }
+        budget.addRow(row)
         group.push(row)
       }
 

--- a/src/execute/budget.js
+++ b/src/execute/budget.js
@@ -1,0 +1,153 @@
+/**
+ * @import { AsyncRow, ExecutionBudget, SqlPrimitive } from '../types.js'
+ */
+
+// Coarse per-value byte estimates used by the buffered-byte ceiling. The byte
+// budget is a cheap safety bound, not exact accounting: lazy cells are never
+// forced in order to measure them, so the estimate is intentionally approximate.
+const STRING_BYTES_PER_CHAR = 2 // one UTF-16 code unit
+const NUMBER_BYTES = 8
+const SMALL_VALUE_BYTES = 4
+const OBJECT_BYTES = 32
+const KEY_OVERHEAD_BYTES = 16 // per buffered cell when no materialized value is available
+const ROW_OVERHEAD_BYTES = 24
+
+/**
+ * Cheap byte estimate for a single buffered primitive value.
+ *
+ * @param {SqlPrimitive} value
+ * @returns {number}
+ */
+export function estimateValueBytes(value) {
+  if (value == null) return 0
+  if (typeof value === 'string') return value.length * STRING_BYTES_PER_CHAR
+  if (typeof value === 'number' || typeof value === 'bigint') return NUMBER_BYTES
+  if (typeof value === 'boolean') return SMALL_VALUE_BYTES
+  if (value instanceof Date) return NUMBER_BYTES
+  return OBJECT_BYTES
+}
+
+/**
+ * Cheap byte estimate for a buffered row. Uses pre-materialized values when the
+ * source exposes them (`row.resolved`); otherwise approximates from the column
+ * count so the estimate stays O(columns) and never forces a lazy cell.
+ *
+ * @param {AsyncRow} row
+ * @returns {number}
+ */
+export function estimateRowBytes(row) {
+  const { resolved } = row
+  if (resolved) {
+    let bytes = ROW_OVERHEAD_BYTES
+    for (const key of Object.keys(resolved)) {
+      bytes += key.length * STRING_BYTES_PER_CHAR + estimateValueBytes(resolved[key])
+    }
+    return bytes
+  }
+  return ROW_OVERHEAD_BYTES + (row.columns?.length ?? 0) * KEY_OVERHEAD_BYTES
+}
+
+/**
+ * Thrown when a buffering operator's in-memory accumulation would exceed the
+ * configured execution budget. The query is refused with no rows: the engine
+ * does not spill to disk or truncate the result. V1 of bounded query execution
+ * refuses over the ceiling rather than spilling or truncating (hypaware LLP 0056).
+ */
+export class QueryBudgetExceededError extends Error {
+  /**
+   * @param {Object} options
+   * @param {string} options.operator - buffering operator that hit the ceiling (e.g. 'ORDER BY')
+   * @param {'rows' | 'bytes'} options.limitKind - which ceiling tripped
+   * @param {number} options.limit - configured ceiling value that was exceeded
+   * @param {number} options.observed - buffered rows/bytes at the point of refusal
+   */
+  constructor({ operator, limitKind, limit, observed }) {
+    super(`Query execution budget exceeded: ${operator} buffered ${observed} ${limitKind}, over the ${limitKind} ceiling of ${limit}`)
+    this.name = 'QueryBudgetExceededError'
+    /** @type {string} */
+    this.operator = operator
+    /** @type {'rows' | 'bytes'} */
+    this.limitKind = limitKind
+    /** @type {number} */
+    this.limit = limit
+    /** @type {number} */
+    this.observed = observed
+  }
+}
+
+/**
+ * Per-operator accountant for the execution budget. A buffering operator
+ * constructs one of these and charges every row (or retained dedup key) it
+ * accumulates in memory; when the configured row or byte ceiling is crossed it
+ * throws {@link QueryBudgetExceededError} instead of continuing to buffer. An
+ * undefined budget — or an undefined ceiling within it — is unbounded: `charge`
+ * only counts and never throws, so callers that pass no budget are unaffected.
+ */
+export class BufferBudget {
+  /**
+   * @param {ExecutionBudget} [budget] - the execution budget, or undefined for unbounded
+   * @param {string} [operator] - operator label for the refusal message
+   */
+  constructor(budget, operator = 'query') {
+    /** @type {number | undefined} */
+    this.maxRows = budget?.maxBufferedRows
+    /** @type {number | undefined} */
+    this.maxBytes = budget?.maxBufferedBytes
+    /** @type {string} */
+    this.operator = operator
+    /** @type {number} */
+    this.rows = 0
+    /** @type {number} */
+    this.bytes = 0
+  }
+
+  /**
+   * Charges one buffered entry of the given estimated size, refusing if either
+   * the row or byte ceiling is crossed.
+   *
+   * @param {number} bytes - estimated bytes retained by this entry
+   * @returns {void}
+   */
+  charge(bytes) {
+    this.rows++
+    if (this.maxRows !== undefined && this.rows > this.maxRows) {
+      throw new QueryBudgetExceededError({
+        operator: this.operator,
+        limitKind: 'rows',
+        limit: this.maxRows,
+        observed: this.rows,
+      })
+    }
+    if (this.maxBytes !== undefined) {
+      this.bytes += bytes
+      if (this.bytes > this.maxBytes) {
+        throw new QueryBudgetExceededError({
+          operator: this.operator,
+          limitKind: 'bytes',
+          limit: this.maxBytes,
+          observed: this.bytes,
+        })
+      }
+    }
+  }
+
+  /**
+   * Charges one buffered row (sort / aggregate row collection).
+   *
+   * @param {AsyncRow} row
+   * @returns {void}
+   */
+  addRow(row) {
+    this.charge(this.maxBytes === undefined ? 0 : estimateRowBytes(row))
+  }
+
+  /**
+   * Charges one retained dedup key (DISTINCT / set-membership buffers).
+   *
+   * @param {SqlPrimitive} key
+   * @returns {void}
+   */
+  addKey(key) {
+    this.charge(this.maxBytes === undefined ? 0 : estimateValueBytes(key))
+  }
+}

--- a/src/execute/budget.js
+++ b/src/execute/budget.js
@@ -48,10 +48,22 @@ export function estimateRowBytes(row) {
 }
 
 /**
- * Thrown when a buffering operator's in-memory accumulation would exceed the
- * configured execution budget. The query is refused with no rows: the engine
- * does not spill to disk or truncate the result. V1 of bounded query execution
- * refuses over the ceiling rather than spilling or truncating (hypaware LLP 0056).
+ * Thrown when an operator's in-memory accumulation would exceed the configured
+ * execution budget. V1 of bounded query execution refuses over the ceiling
+ * rather than spilling to disk or truncating (hypaware LLP 0056).
+ *
+ * What "refused" means for an already-running query depends on the operator
+ * class:
+ *
+ * - Buffering operators (ORDER BY, GROUP BY, the scalar-aggregate slow path)
+ *   fully buffer their input before they can emit a row, so the refusal is
+ *   all-or-nothing: the error is thrown before the first row is yielded and no
+ *   partial result escapes.
+ * - Streaming operators (DISTINCT, COUNT(DISTINCT)) emit as they go and bound
+ *   only their dedup-set memory, so rows 1..N may already have been yielded
+ *   before a later key trips the ceiling. A consumer MUST treat a thrown
+ *   QueryBudgetExceededError as invalidating the whole result — discarding any
+ *   rows it already received — never as a spill or a truncation point.
  */
 export class QueryBudgetExceededError extends Error {
   /**
@@ -76,9 +88,9 @@ export class QueryBudgetExceededError extends Error {
 }
 
 /**
- * Per-operator accountant for the execution budget. A buffering operator
- * constructs one of these and charges every row (or retained dedup key) it
- * accumulates in memory; when the configured row or byte ceiling is crossed it
+ * Per-operator accountant for the execution budget. An operator constructs one
+ * of these and charges every row (or retained dedup key) it accumulates in
+ * memory; when the configured row or byte ceiling is crossed it
  * throws {@link QueryBudgetExceededError} instead of continuing to buffer. An
  * undefined budget — or an undefined ceiling within it — is unbounded: `charge`
  * only counts and never throws, so callers that pass no budget are unaffected.

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -1,4 +1,5 @@
 import { memorySource } from '../backend/dataSource.js'
+import { BufferBudget } from './budget.js'
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { parseSql } from '../parse/parse.js'
@@ -26,7 +27,7 @@ const YIELD_INTERVAL = 4000
  * @param {ExecuteSqlOptions} options
  * @returns {QueryResults}
  */
-export function executeSql({ tables, query, functions, signal }) {
+export function executeSql({ tables, query, functions, signal, budget }) {
   const parsed = typeof query === 'string' ? parseSql({ query, functions }) : query
 
   // Normalize tables: convert arrays to AsyncDataSource
@@ -49,7 +50,7 @@ export function executeSql({ tables, query, functions, signal }) {
   const ctePlans = new Map()
   /** @type {Map<string, string[]>} */
   const cteColumns = new Map()
-  const context = { tables: normalizedTables, functions, signal, scope, ctePlans, cteColumns }
+  const context = { tables: normalizedTables, functions, signal, budget, scope, ctePlans, cteColumns }
   const plan = planSql({ query: parsed, functions, tables: normalizedTables, ctePlans, cteColumns })
   return executePlan({ plan, context })
 }
@@ -603,6 +604,10 @@ function executeDistinct(plan, context) {
       const { signal } = context
       const MAX_CHUNK = 256
 
+      // The distinct-key set grows with the number of distinct rows, so it is
+      // bounded by the execution budget; over the ceiling we refuse rather than
+      // spill or truncate (hypaware LLP 0056).
+      const budget = new BufferBudget(context.budget, 'DISTINCT')
       const seen = new Set()
 
       /** @type {AsyncRow[]} */
@@ -622,6 +627,7 @@ function executeDistinct(plan, context) {
           for (let i = 0; i < buffer.length; i++) {
             const key = await keys[i]
             if (!seen.has(key)) {
+              budget.addKey(key)
               seen.add(key)
               yield buffer[i]
             }
@@ -636,6 +642,7 @@ function executeDistinct(plan, context) {
         for (let i = 0; i < buffer.length; i++) {
           const key = await keys[i]
           if (!seen.has(key)) {
+            budget.addKey(key)
             seen.add(key)
             yield buffer[i]
           }

--- a/src/execute/sort.js
+++ b/src/execute/sort.js
@@ -1,5 +1,6 @@
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
+import { BufferBudget } from './budget.js'
 import { executePlan } from './execute.js'
 import { compareForTerm } from './utils.js'
 
@@ -129,11 +130,15 @@ export function executeSort(plan, context) {
     numRows: child.numRows,
     maxRows: child.maxRows,
     async *rows() {
-      // Buffer all rows
+      // ORDER BY must buffer the whole input before it can emit its first row.
+      // Bound that buffer with the execution budget and refuse over the
+      // ceiling rather than spill or truncate (hypaware LLP 0056).
+      const budget = new BufferBudget(context.budget, 'ORDER BY')
       /** @type {AsyncRow[]} */
       const rows = []
       for await (const row of child.rows()) {
         if (context.signal?.aborted) return
+        budget.addRow(row)
         rows.push(row)
       }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,10 +36,18 @@ export type {
 export function executeSql(options: ExecuteSqlOptions): QueryResults
 
 /**
- * Error thrown when a buffering operator (ORDER BY, GROUP BY, DISTINCT, or the
- * scalar-aggregate slow path) would accumulate more in-memory state than the
- * configured execution budget allows. The query is refused with no rows; the
- * engine does not spill to disk or truncate the result.
+ * Error thrown when an operator would accumulate more in-memory state than the
+ * configured execution budget allows. V1 refuses over the ceiling; the engine
+ * does not spill to disk or truncate the result.
+ *
+ * The emit contract depends on the operator:
+ * - Buffering operators (ORDER BY, GROUP BY, the scalar-aggregate slow path)
+ *   fully buffer before emitting, so the refusal is all-or-nothing: the error
+ *   is thrown before any row is yielded.
+ * - Streaming operators (DISTINCT, COUNT(DISTINCT)) bound only their dedup-set
+ *   memory and may already have yielded rows before a later key trips the
+ *   ceiling. A consumer must treat a thrown error as invalidating the whole
+ *   result, not as a truncation point.
  */
 export class QueryBudgetExceededError extends Error {
   constructor(options: { operator: string, limitKind: 'rows' | 'bytes', limit: number, observed: number })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export type {
   AsyncRow,
   ExecuteContext,
   ExecuteSqlOptions,
+  ExecutionBudget,
   ExprNode,
   ParseSqlOptions,
   PlanSqlOptions,
@@ -29,9 +30,28 @@ export type {
  * @param options.query - SQL query string
  * @param options.functions - user-defined functions available in the SQL context
  * @param options.signal - AbortSignal to cancel the query
+ * @param options.budget - execution budget for in-memory buffering operators
  * @returns async generator yielding rows matching the query
  */
 export function executeSql(options: ExecuteSqlOptions): QueryResults
+
+/**
+ * Error thrown when a buffering operator (ORDER BY, GROUP BY, DISTINCT, or the
+ * scalar-aggregate slow path) would accumulate more in-memory state than the
+ * configured execution budget allows. The query is refused with no rows; the
+ * engine does not spill to disk or truncate the result.
+ */
+export class QueryBudgetExceededError extends Error {
+  constructor(options: { operator: string, limitKind: 'rows' | 'bytes', limit: number, observed: number })
+  // buffering operator that hit the ceiling (e.g. 'ORDER BY')
+  operator: string
+  // which ceiling tripped
+  limitKind: 'rows' | 'bytes'
+  // configured ceiling value that was exceeded
+  limit: number
+  // buffered rows/bytes at the point of refusal
+  observed: number
+}
 
 /**
  * Executes a query plan and yields result rows

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { executePlan, executeSql } from './execute/execute.js'
+export { QueryBudgetExceededError } from './execute/budget.js'
 export { extractTables } from './parse/extractTables.js'
 export { parseSql } from './parse/parse.js'
 export { planSql } from './plan/plan.js'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -22,12 +22,27 @@ export interface ParseSqlOptions {
 }
 
 /**
- * Execution budget: ceilings on the in-memory state that buffering operators
- * (ORDER BY, GROUP BY, DISTINCT, the scalar-aggregate slow path) may accumulate
- * before the engine refuses the query with a QueryBudgetExceededError. This
- * bounds execution memory and is distinct from any display/output-size control,
- * which trims an already-materialized result. Whichever ceiling trips first
- * wins; an undefined ceiling (or an undefined budget) is unbounded.
+ * Execution budget: ceilings on the in-memory state that bounded operators may
+ * accumulate before the engine refuses the query with a
+ * QueryBudgetExceededError. This bounds execution memory and is distinct from
+ * any display/output-size control, which trims an already-materialized result.
+ * Whichever ceiling trips first wins; an undefined ceiling (or an undefined
+ * budget) is unbounded.
+ *
+ * Bounded in V1: ORDER BY, GROUP BY, the scalar-aggregate slow path, DISTINCT,
+ * and COUNT(DISTINCT) (including its column-scan fast path). ORDER BY, GROUP BY,
+ * and the scalar-aggregate slow path fully buffer and refuse before emitting any
+ * row; DISTINCT and COUNT(DISTINCT) bound only their dedup-set memory and may
+ * emit rows before refusing (a thrown error invalidates the whole result, see
+ * QueryBudgetExceededError).
+ *
+ * NOT bounded in V1 (known limitations / follow-up): joins (nested-loop,
+ * positional, and the hash-join build side), window functions (the
+ * non-streaming path), and set operations (the UNION / INTERSECT / EXCEPT key
+ * sets). These can still grow memory without limit even when a budget is set.
+ *
+ * Plain streaming aggregates (COUNT / SUM / MIN / MAX / AVG over a scanned
+ * column) hold O(1) state and are intentionally budget-immune.
  */
 export interface ExecutionBudget {
   // Max rows a single buffering operator may hold before refusing.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,12 +21,30 @@ export interface ParseSqlOptions {
   functions?: Record<string, UserDefinedFunction>
 }
 
+/**
+ * Execution budget: ceilings on the in-memory state that buffering operators
+ * (ORDER BY, GROUP BY, DISTINCT, the scalar-aggregate slow path) may accumulate
+ * before the engine refuses the query with a QueryBudgetExceededError. This
+ * bounds execution memory and is distinct from any display/output-size control,
+ * which trims an already-materialized result. Whichever ceiling trips first
+ * wins; an undefined ceiling (or an undefined budget) is unbounded.
+ */
+export interface ExecutionBudget {
+  // Max rows a single buffering operator may hold before refusing.
+  maxBufferedRows?: number
+  // Max estimated bytes of buffered cell values a single buffering operator may
+  // hold before refusing.
+  maxBufferedBytes?: number
+}
+
 // executeSql(options)
 export interface ExecuteSqlOptions {
   tables: Record<string, Row | AsyncDataSource>
   query: string | Statement
   functions?: Record<string, UserDefinedFunction>
   signal?: AbortSignal
+  // Execution budget for in-memory buffering operators. Undefined = unbounded.
+  budget?: ExecutionBudget
 }
 
 // planSql(options)
@@ -46,6 +64,8 @@ export interface ExecuteContext {
   tables: Record<string, AsyncDataSource>
   functions?: Record<string, UserDefinedFunction>
   signal?: AbortSignal
+  // execution budget threaded to buffering operators (see ExecutionBudget)
+  budget?: ExecutionBudget
   // current query's FROM + JOIN aliases (e.g. ['a', 'b'])
   scope?: string[]
   // the enclosing query's current row, for resolving correlated references

--- a/test/execute/budget.test.js
+++ b/test/execute/budget.test.js
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { QueryBudgetExceededError, collect, executeSql } from '../../src/index.js'
+import { memorySource } from '../../src/backend/dataSource.js'
+
+/**
+ * @import { AsyncDataSource } from '../../src/types.js'
+ */
+
+/** @type {{ id: number, bucket: number }[]} */
+const rows = []
+for (let i = 0; i < 10; i++) rows.push({ id: i, bucket: i % 3 })
+
+/**
+ * Runs a query to completion and returns the error it throws, asserting that it
+ * is a QueryBudgetExceededError.
+ *
+ * @param {import('../../src/types.js').ExecuteSqlOptions} options
+ * @returns {Promise<QueryBudgetExceededError>}
+ */
+async function captureBudgetError(options) {
+  let caught
+  try {
+    await collect(executeSql(options))
+  } catch (err) {
+    caught = err
+  }
+  expect(caught).toBeInstanceOf(QueryBudgetExceededError)
+  if (caught instanceof QueryBudgetExceededError) return caught
+  throw new Error('expected QueryBudgetExceededError, but the query succeeded')
+}
+
+describe('execution budget', () => {
+  describe('refuses over the buffered-row ceiling', () => {
+    it('ORDER BY beyond the row ceiling throws QueryBudgetExceededError', async () => {
+      const err = await captureBudgetError({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT * FROM s ORDER BY id',
+        budget: { maxBufferedRows: 5 },
+      })
+      expect(err.operator).toBe('ORDER BY')
+      expect(err.limitKind).toBe('rows')
+      expect(err.limit).toBe(5)
+      expect(err.observed).toBe(6)
+    })
+
+    it('scalar-aggregate slow path beyond the row ceiling throws QueryBudgetExceededError', async () => {
+      // SUM of a derived expression bypasses the scanColumn fast path, so the
+      // whole input is collected into one group and the budget bites.
+      const err = await captureBudgetError({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT SUM(id + 1) AS total FROM s',
+        budget: { maxBufferedRows: 5 },
+      })
+      expect(err.operator).toBe('aggregate')
+      expect(err.limitKind).toBe('rows')
+      expect(err.limit).toBe(5)
+    })
+
+    it('GROUP BY beyond the row ceiling throws QueryBudgetExceededError', async () => {
+      const err = await captureBudgetError({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT bucket, COUNT(*) AS n FROM s GROUP BY bucket',
+        budget: { maxBufferedRows: 5 },
+      })
+      expect(err.operator).toBe('GROUP BY')
+      expect(err.limit).toBe(5)
+    })
+
+    it('DISTINCT beyond the row ceiling throws QueryBudgetExceededError', async () => {
+      const err = await captureBudgetError({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT DISTINCT id FROM s',
+        budget: { maxBufferedRows: 5 },
+      })
+      expect(err.operator).toBe('DISTINCT')
+      expect(err.limit).toBe(5)
+    })
+  })
+
+  describe('refuses over the buffered-byte ceiling', () => {
+    it('ORDER BY beyond the byte ceiling throws with limitKind bytes', async () => {
+      const err = await captureBudgetError({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT * FROM s ORDER BY id',
+        // Each buffered row estimates to well over 1 byte, so the byte ceiling
+        // trips before all 10 rows are buffered.
+        budget: { maxBufferedBytes: 1 },
+      })
+      expect(err.operator).toBe('ORDER BY')
+      expect(err.limitKind).toBe('bytes')
+      expect(err.limit).toBe(1)
+    })
+  })
+
+  describe('under the ceiling succeeds normally', () => {
+    it('ORDER BY under the row ceiling returns all sorted rows', async () => {
+      const result = await collect(executeSql({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT id FROM s ORDER BY id DESC',
+        budget: { maxBufferedRows: 100 },
+      }))
+      expect(result).toHaveLength(10)
+      expect(result[0]).toEqual({ id: 9 })
+      expect(result[9]).toEqual({ id: 0 })
+    })
+
+    it('scalar aggregate under the row ceiling returns the aggregate', async () => {
+      const result = await collect(executeSql({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT SUM(id + 1) AS total FROM s',
+        budget: { maxBufferedRows: 100 },
+      }))
+      expect(result).toEqual([{ total: 55 }])
+    })
+
+    it('a query with no budget is unbounded (backward compatible)', async () => {
+      const result = await collect(executeSql({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT * FROM s ORDER BY id',
+      }))
+      expect(result).toHaveLength(10)
+    })
+  })
+
+  describe('streaming paths bypass the budget', () => {
+    it('a streaming column-scan aggregate is NOT affected by a low ceiling', async () => {
+      // This source streams a single column via scanColumn and throws if its
+      // buffering `scan` path is ever taken, proving the aggregate fast path
+      // holds O(1) state and never consults the budget.
+      let scanColumnCalls = 0
+      /** @type {AsyncDataSource} */
+      const streamingSource = {
+        numRows: 100,
+        columns: ['id'],
+        scan() {
+          throw new Error('scan (buffering path) should not be called')
+        },
+        async *scanColumn() {
+          scanColumnCalls++
+          const first = []
+          for (let i = 0; i < 50; i++) first.push(i)
+          yield first
+          const second = []
+          for (let i = 50; i < 100; i++) second.push(i)
+          yield second
+        },
+      }
+
+      const result = await collect(executeSql({
+        tables: { data: streamingSource },
+        query: 'SELECT COUNT(id) AS n FROM data',
+        // A ceiling of 1 would refuse any buffering operator immediately.
+        budget: { maxBufferedRows: 1, maxBufferedBytes: 1 },
+      }))
+
+      expect(result).toEqual([{ n: 100 }])
+      expect(scanColumnCalls).toBe(1)
+    })
+  })
+})

--- a/test/execute/budget.test.js
+++ b/test/execute/budget.test.js
@@ -3,7 +3,7 @@ import { QueryBudgetExceededError, collect, executeSql } from '../../src/index.j
 import { memorySource } from '../../src/backend/dataSource.js'
 
 /**
- * @import { AsyncDataSource } from '../../src/types.js'
+ * @import { AsyncDataSource, SqlPrimitive } from '../../src/types.js'
  */
 
 /** @type {{ id: number, bucket: number }[]} */
@@ -119,6 +119,95 @@ describe('execution budget', () => {
         query: 'SELECT * FROM s ORDER BY id',
       }))
       expect(result).toHaveLength(10)
+    })
+  })
+
+  describe('streaming operators emit before refusing (not all-or-nothing)', () => {
+    it('DISTINCT emits rows up to the ceiling, then throws mid-stream', async () => {
+      // DISTINCT is a streaming operator: it bounds only its dedup-set memory and
+      // yields each new distinct row as it sees it. So unlike the buffering
+      // operators (which throw before emitting any row), DISTINCT has ALREADY
+      // emitted rows 1..ceiling by the time a later key trips the budget. The
+      // contract is that a thrown error invalidates the whole result.
+      const results = executeSql({
+        tables: { s: memorySource({ data: rows }) },
+        query: 'SELECT DISTINCT id FROM s',
+        budget: { maxBufferedRows: 5 },
+      })
+
+      /** @type {Record<string, SqlPrimitive>[]} */
+      const emitted = []
+      let caught
+      try {
+        for await (const row of results.rows()) {
+          /** @type {Record<string, SqlPrimitive>} */
+          const obj = {}
+          for (const col of row.columns) obj[col] = await row.cells[col]()
+          emitted.push(obj)
+        }
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeInstanceOf(QueryBudgetExceededError)
+      // The first five distinct rows were emitted before the sixth key tripped
+      // the ceiling; a consumer must discard them, not treat them as truncated.
+      expect(emitted).toEqual([{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }])
+    })
+  })
+
+  describe('COUNT(DISTINCT) fast path is bounded; plain COUNT stays immune', () => {
+    /**
+     * A scanColumn-only source streaming `count` ascending distinct ids in two
+     * chunks. Its buffering `scan` path throws, proving the column-scan fast
+     * path is taken rather than the buffered slow path.
+     *
+     * @param {number} count
+     * @returns {AsyncDataSource}
+     */
+    function scanColumnSource(count) {
+      return {
+        numRows: count,
+        columns: ['id'],
+        scan() {
+          throw new Error('scan (buffering path) should not be called')
+        },
+        async *scanColumn() {
+          const half = Math.floor(count / 2)
+          /** @type {number[]} */
+          const first = []
+          for (let i = 0; i < half; i++) first.push(i)
+          yield first
+          /** @type {number[]} */
+          const second = []
+          for (let i = half; i < count; i++) second.push(i)
+          yield second
+        },
+      }
+    }
+
+    it('COUNT(DISTINCT id) past the ceiling throws QueryBudgetExceededError', async () => {
+      // COUNT(DISTINCT) retains O(distinct) dedup keys even on the scanColumn
+      // fast path, so a budget must bound it or a high-cardinality column OOMs.
+      const err = await captureBudgetError({
+        tables: { data: scanColumnSource(100) },
+        query: 'SELECT COUNT(DISTINCT id) AS n FROM data',
+        budget: { maxBufferedRows: 10 },
+      })
+      expect(err.operator).toBe('COUNT(DISTINCT)')
+      expect(err.limitKind).toBe('rows')
+      expect(err.limit).toBe(10)
+    })
+
+    it('COUNT(id) over the same source with the same low ceiling stays immune (O(1))', async () => {
+      // Plain COUNT holds O(1) state, so the same ceiling that refuses
+      // COUNT(DISTINCT) must not bite it.
+      const result = await collect(executeSql({
+        tables: { data: scanColumnSource(100) },
+        query: 'SELECT COUNT(id) AS n FROM data',
+        budget: { maxBufferedRows: 10, maxBufferedBytes: 10 },
+      }))
+      expect(result).toEqual([{ n: 100 }])
     })
   })
 


### PR DESCRIPTION
## What

Adds a per-run **execution budget** to the public `executeSql` surface and makes the buffering operators refuse over it with a new exported typed error, `QueryBudgetExceededError`.

`ExecuteSqlOptions` gains `budget?: ExecutionBudget`:

```ts
interface ExecutionBudget {
  maxBufferedRows?: number   // ceiling on rows a single buffering operator may hold
  maxBufferedBytes?: number  // ceiling on estimated bytes of buffered cell values
}
```

It threads onto the execution context exactly like `signal` (`context.budget`), so every operator sees it. An undefined budget — or an undefined ceiling within it — is **unbounded**, so existing callers are unaffected (all 1697 existing tests pass unchanged).

## Why — refuse, don't spill or truncate

The buffering operators (`ORDER BY`, high-cardinality `GROUP BY`, `DISTINCT`, and the scalar-aggregate slow path) accumulate the whole scanned input in memory before they can emit a row. Over a large dataset that exhausts the heap and OOM-kills the host process for every caller. V1 of the fix **refuses over a ceiling rather than spill to disk or truncate**: a partial `COUNT(DISTINCT …)` / `GROUP BY` would undercount silently, and a sorted prefix is only correct after the full input is already buffered — the exact memory the budget exists to avoid. When a ceiling is crossed the operator throws `QueryBudgetExceededError` (carrying `operator`, `limitKind`, `limit`, `observed`) and returns no rows. No spill, no truncation.

## Enforced at (the buffering sites)

- `src/execute/sort.js` — `executeSort` row buffer (`ORDER BY`)
- `src/execute/aggregates.js` — `executeScalarAggregate` slow-path group collection (`aggregate`) and `executeHashAggregate` row collection (`GROUP BY`)
- `src/execute/execute.js` — `executeDistinct` dedup-key set (`DISTINCT`)

A shared `BufferBudget` accountant (`src/execute/budget.js`) charges each buffered row/key and throws when over; the byte estimate is a cheap O(columns) bound that never forces a lazy cell.

## Streaming paths are unaffected

The `tryColumnScanAggregate` / `scanColumnAggregate` fast path holds an O(1) accumulator (or an O(cardinality) distinct set) and **never constructs a budget**, so a low ceiling does not bite `COUNT`/`MIN`/`MAX`/`SUM`/`AVG` (or low-card `COUNT(DISTINCT …)`) over a streamed column. Proven by the test `a streaming column-scan aggregate is NOT affected by a low ceiling`, which runs `COUNT(id)` with `{ maxBufferedRows: 1, maxBufferedBytes: 1 }` over a `scanColumn` source whose buffering `scan` throws if ever called — and still returns the full count.

## API added

- `QueryBudgetExceededError` — exported from `src/index.js`, declared in `src/index.d.ts`, defined in `src/execute/budget.js`.
- `ExecutionBudget` interface + `ExecuteSqlOptions.budget` + `ExecuteContext.budget` in `src/types.d.ts`.

## Tests

`test/execute/budget.test.js` (9 tests): row-ceiling refusal for `ORDER BY`, the scalar-aggregate slow path, `GROUP BY`, and `DISTINCT` (asserting error type + `operator`/`limit`); byte-ceiling refusal (`limitKind: 'bytes'`); under-ceiling success; no-budget backward compatibility; and the streaming-bypass proof. Gates: `npm test` 1697 passed, `npm run lint` clean, `npx tsc --noEmit` clean.

---

Part of the hypaware bounded-query-execution effort (design: hypaware LLP 0058, decision LLP 0056; task T6).