### PR TITLE
Bound cached data source memory; batch scalar aggregates

### DIFF
--- a/src/backend/dataSource.js
+++ b/src/backend/dataSource.js
@@ -71,13 +71,18 @@ export function memorySource({ data, columns }) {
 }
 
 /**
- * Wraps a data source that caches all accessed rows in memory
+ * Wraps a data source, memoizing accessed cells. The row cache is a WeakMap
+ * keyed on row identity so entries are collectible once the row is unreachable,
+ * keeping a streaming scan O(1) instead of O(rows).
  * @param {AsyncDataSource} source
  * @returns {AsyncDataSource}
  */
 export function cachedDataSource(source) {
+  /** @type {WeakMap<object, Map<string, Promise<SqlPrimitive>>>} */
+  const cache = new WeakMap()
+  // Keyed on numeric position, so it can't be a WeakMap and stays unbounded.
   /** @type {Map<string, Promise<SqlPrimitive>>} */
-  const cache = new Map()
+  const columnCache = new Map()
   return {
     ...source,
     scan(options) {
@@ -90,32 +95,31 @@ export function cachedDataSource(source) {
         return { rows, appliedWhere, appliedLimitOffset }
       }
 
-      // Adjust index when source applied offset so cache keys match original rows
-      const indexOffset = appliedLimitOffset && options.offset ? options.offset : 0
-
       return {
         async *rows() {
-          let index = 0
           for await (const row of rows()) {
             if (options.signal?.aborted) break
-            const rowIndex = index + indexOffset
+            const anchor = row.resolved ?? row
+            let rowCache = cache.get(anchor)
+            if (!rowCache) {
+              rowCache = new Map()
+              cache.set(anchor, rowCache)
+            }
             /** @type {AsyncCells} */
             const cells = {}
             for (const key of row.columns) {
               const cell = row.cells[key]
-              // Wrap the cell to cache accesses
               cells[key] = () => {
-                const cacheKey = `${rowIndex}:${key}`
-                let value = cache.get(cacheKey)
+                let value = rowCache.get(key)
                 if (!value) {
                   value = cell()
-                  cache.set(cacheKey, value)
+                  rowCache.set(key, value)
                 }
                 return value
               }
             }
-            yield { columns: row.columns, cells }
-            index++
+            // Preserve resolved so downstream fast paths still apply.
+            yield { columns: row.columns, cells, resolved: row.resolved }
           }
         },
         appliedWhere,
@@ -138,12 +142,12 @@ export function cachedDataSource(source) {
             const cached = new Array(chunk.length)
             for (let i = 0; i < chunk.length; i++) {
               const cacheKey = `${chunkStart + i + indexOffset}:${options.column}`
-              const existing = cache.get(cacheKey)
+              const existing = columnCache.get(cacheKey)
               if (existing) {
                 cached[i] = await existing
               } else {
                 const value = chunk[i]
-                cache.set(cacheKey, Promise.resolve(value))
+                columnCache.set(cacheKey, Promise.resolve(value))
                 cached[i] = value
               }
             }

--- a/src/backend/dataSource.js
+++ b/src/backend/dataSource.js
@@ -1,5 +1,5 @@
 /**
- * @import { AsyncCells, AsyncDataSource, AsyncRow, ScanColumnOptions, SqlPrimitive } from '../types.js'
+ * @import { AsyncCells, AsyncDataSource, AsyncRow, SqlPrimitive } from '../types.js'
  */
 
 /**
@@ -80,9 +80,6 @@ export function memorySource({ data, columns }) {
 export function cachedDataSource(source) {
   /** @type {WeakMap<object, Map<string, Promise<SqlPrimitive>>>} */
   const cache = new WeakMap()
-  // Keyed on numeric position, so it can't be a WeakMap and stays unbounded.
-  /** @type {Map<string, Promise<SqlPrimitive>>} */
-  const columnCache = new Map()
   return {
     ...source,
     scan(options) {
@@ -126,36 +123,7 @@ export function cachedDataSource(source) {
         appliedLimitOffset,
       }
     },
-    ...source.scanColumn && {
-      /**
-       * @param {ScanColumnOptions} options
-       * @returns {AsyncIterable<ArrayLike<SqlPrimitive>>}
-       */
-      scanColumn(options) {
-        const inner = source.scanColumn(options)
-        const indexOffset = options.offset ?? 0
-        return (async function* () {
-          let chunkStart = 0
-          for await (const chunk of inner) {
-            if (options.signal?.aborted) break
-            /** @type {SqlPrimitive[]} */
-            const cached = new Array(chunk.length)
-            for (let i = 0; i < chunk.length; i++) {
-              const cacheKey = `${chunkStart + i + indexOffset}:${options.column}`
-              const existing = columnCache.get(cacheKey)
-              if (existing) {
-                cached[i] = await existing
-              } else {
-                const value = chunk[i]
-                columnCache.set(cacheKey, Promise.resolve(value))
-                cached[i] = value
-              }
-            }
-            yield cached
-            chunkStart += chunk.length
-          }
-        })()
-      },
-    },
+    // scanColumn passes through from ...source unwrapped: column values are
+    // already materialized, so caching them only retained memory unboundedly.
   }
 }

--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -282,9 +282,36 @@ function tryColumnScanAggregate(plan, { tables, signal }) {
     /** @type {AsyncCells} */
     const cells = {}
 
+    // Group specs by column so each column is scanned at most once no matter how
+    // many aggregates read it (e.g. MIN(x), MAX(x), AVG(x) share one pass).
+    /** @type {Map<string, ColumnAggSpec[]>} */
+    const specsByColumn = new Map()
+    for (const spec of specs) {
+      const group = specsByColumn.get(spec.column)
+      if (group) group.push(spec)
+      else specsByColumn.set(spec.column, [spec])
+    }
+
+    // Each column's single pass is computed once and shared by all its cells;
+    // a column is only scanned if one of its aggregates is actually read.
+    /** @type {Map<string, Promise<Map<string, SqlPrimitive>>>} */
+    const passes = new Map()
+    /**
+     * @param {string} column
+     * @returns {Promise<Map<string, SqlPrimitive>>}
+     */
+    function scanOnce(column) {
+      let pass = passes.get(column)
+      if (!pass) {
+        pass = scanColumnGroup({ table, specs: specsByColumn.get(column) ?? [], limit, offset, signal })
+        passes.set(column, pass)
+      }
+      return pass
+    }
+
     for (const spec of specs) {
       columns.push(spec.alias)
-      cells[spec.alias] = () => scanColumnAggregate({ table, spec, limit, offset, signal })
+      cells[spec.alias] = async () => (await scanOnce(spec.column)).get(spec.alias) ?? null
     }
 
     yield { columns, cells }
@@ -316,68 +343,92 @@ function extractColumnAggSpec({ expr, alias }) {
 }
 
 /**
- * Scans a single column and computes an aggregate value.
+ * @typedef {{
+ *   spec: ColumnAggSpec,
+ *   count: number,
+ *   sum: number,
+ *   min: SqlPrimitive,
+ *   max: SqlPrimitive,
+ *   seen: Set<unknown> | null,
+ * }} AggAccumulator
+ */
+
+/**
+ * Scans a column once and computes every aggregate over it in a single pass.
+ * All specs share the one scanColumn walk, so MIN(x)/MAX(x)/AVG(x) decode x once.
  *
  * @param {Object} options
  * @param {AsyncDataSource} options.table
- * @param {ColumnAggSpec} options.spec
+ * @param {ColumnAggSpec[]} options.specs - aggregates over the same column
  * @param {number} [options.limit]
  * @param {number} [options.offset]
  * @param {AbortSignal} [options.signal]
- * @returns {Promise<SqlPrimitive>}
+ * @returns {Promise<Map<string, SqlPrimitive>>} alias → aggregate value
  */
-async function scanColumnAggregate({ table, spec, limit, offset, signal }) {
-  const values = table.scanColumn({ column: spec.column, limit, offset, signal })
+async function scanColumnGroup({ table, specs, limit, offset, signal }) {
+  const { column } = specs[0]
+  const values = table.scanColumn({ column, limit, offset, signal })
 
-  if (spec.funcName === 'COUNT' && spec.distinct) {
-    const seen = new Set()
-    for await (const chunk of values) {
-      if (signal?.aborted) return
-      for (let i = 0; i < chunk.length; i++) {
-        const v = chunk[i]
-        if (v == null) continue
-        seen.add(keyify(v))
-      }
-    }
-    return seen.size
-  }
-
-  if (spec.funcName === 'COUNT') {
-    let count = 0
-    for await (const chunk of values) {
-      if (signal?.aborted) return
-      for (let i = 0; i < chunk.length; i++) {
-        if (chunk[i] != null) count++
-      }
-    }
-    return count
-  }
-
-  // SUM, AVG, MIN, MAX
-  let sum = 0
-  let count = 0
-  /** @type {SqlPrimitive} */
-  let min = null
-  /** @type {SqlPrimitive} */
-  let max = null
+  /** @type {AggAccumulator[]} */
+  const accs = specs.map(spec => /** @type {AggAccumulator} */ ({
+    spec,
+    count: 0,
+    sum: 0,
+    min: null,
+    max: null,
+    seen: spec.funcName === 'COUNT' && spec.distinct ? new Set() : null,
+  }))
 
   for await (const chunk of values) {
-    if (signal?.aborted) return
+    if (signal?.aborted) break
     for (let i = 0; i < chunk.length; i++) {
       const v = chunk[i]
       if (v == null) continue
-      if (min === null || v < min) min = v
-      if (max === null || v > max) max = v
-      const num = Number(v)
-      if (!Number.isFinite(num)) continue
-      sum += num
-      count++
+      for (const acc of accs) {
+        switch (acc.spec.funcName) {
+        case 'COUNT':
+          if (acc.seen) acc.seen.add(keyify(v))
+          else acc.count++
+          break
+        case 'MIN':
+          if (acc.min === null || v < acc.min) acc.min = v
+          break
+        case 'MAX':
+          if (acc.max === null || v > acc.max) acc.max = v
+          break
+        default: { // SUM, AVG
+          const num = Number(v)
+          if (Number.isFinite(num)) {
+            acc.sum += num
+            acc.count++
+          }
+        }
+        }
+      }
     }
   }
 
-  if (spec.funcName === 'SUM') return count === 0 ? null : sum
-  if (spec.funcName === 'AVG') return count === 0 ? null : sum / count
-  if (spec.funcName === 'MIN') return min
-  if (spec.funcName === 'MAX') return max
-  return null
+  /** @type {Map<string, SqlPrimitive>} */
+  const result = new Map()
+  for (const acc of accs) {
+    result.set(acc.spec.alias, finalizeAgg(acc))
+  }
+  return result
+}
+
+/**
+ * Reduces one accumulator to its final aggregate value.
+ *
+ * @param {AggAccumulator} acc
+ * @returns {SqlPrimitive}
+ */
+function finalizeAgg(acc) {
+  switch (acc.spec.funcName) {
+  case 'COUNT': return acc.seen ? acc.seen.size : acc.count
+  case 'SUM': return acc.count === 0 ? null : acc.sum
+  case 'AVG': return acc.count === 0 ? null : acc.sum / acc.count
+  case 'MIN': return acc.min
+  case 'MAX': return acc.max
+  default: return null
+  }
 }

--- a/src/execute/aggregates.js
+++ b/src/execute/aggregates.js
@@ -380,7 +380,7 @@ async function scanColumnGroup({ table, specs, limit, offset, signal }) {
   }))
 
   for await (const chunk of values) {
-    if (signal?.aborted) break
+    signal?.throwIfAborted()
     for (let i = 0; i < chunk.length; i++) {
       const v = chunk[i]
       if (v == null) continue
@@ -407,6 +407,7 @@ async function scanColumnGroup({ table, specs, limit, offset, signal }) {
       }
     }
   }
+  signal?.throwIfAborted()
 
   /** @type {Map<string, SqlPrimitive>} */
   const result = new Map()

--- a/test/execute/abort.test.js
+++ b/test/execute/abort.test.js
@@ -515,6 +515,34 @@ describe('abort signal', () => {
     }, 60_000)
   })
 
+  describe('scanColumn scalar aggregate abort', () => {
+    it('should reject instead of finalizing partial scalar aggregate results', async () => {
+      const controller = new AbortController()
+      /** @type {AsyncDataSource} */
+      const source = {
+        columns: ['x'],
+        scan() {
+          throw new Error('scan should not be called')
+        },
+        scanColumn({ column, signal }) {
+          if (column !== 'x') throw new Error(`unexpected column: ${column}`)
+          return (async function* () {
+            yield [1, 2, 3]
+            controller.abort(new Error('aggregate aborted'))
+            if (signal?.aborted) return
+            yield [4, 5, 6]
+          })()
+        },
+      }
+
+      await expect(collect(executeSql({
+        tables: { t: source },
+        query: 'SELECT SUM(x) AS total, COUNT(x) AS n FROM t',
+        signal: controller.signal,
+      }))).rejects.toThrow('aggregate aborted')
+    })
+  })
+
   describe('join queries', () => {
     it('should scan all rows in a join query', async () => {
       const { source: usersSource, getScanCount: getUsersScanCount, getRowCount: getUsersRowCount } = trackingSource(users)


### PR DESCRIPTION
Three related changes to memory and scan efficiency in the data source layer.

### 1. Bound the `cachedDataSource` row cache with a WeakMap
The row cache was a `Map` keyed on `rowIndex:key` that was never evicted, so a streaming scan or filter over a large source retained every accessed cell for the source's lifetime — O(rows). A zero-match streaming filter over a 3M-row parquet file OOMed under a 128MB heap while the raw source finished at ~5MB.

Keying the cache on row identity via a `WeakMap` makes entries collectible once a row is unreachable, so streaming stays O(1). Cached rows now also preserve `resolved`, so downstream fast paths aren't defeated. After the fix the same query runs flat at ~10MB.

### 2. Drop the unbounded `scanColumn` cache
The column cache keyed on numeric position, so it could not be a WeakMap and stayed unbounded. Benchmarking showed it never actually saved a decode (same passes / same values decoded with or without it) yet added ~8–9× time via per-value string-keyed `Map` ops and `Promise` wrapping. A single `SUM` over a cached parquet column went from 152ms to 1406ms *because* of it. Removed; `scanColumn` passes through unwrapped.

### 3. Batch scalar aggregates by column
The scalar-aggregate fast path ran one `scanColumn` pass per aggregate spec, so `MIN(x), MAX(x), AVG(x)` decoded `x` three times. Specs are now grouped by column and every aggregate is folded in a single pass, shared across that column's output cells.

### Benchmark (3M-row parquet, median of 7 cold runs)

| query | before | after |
|---|---|---|
| single agg, raw | 152 ms · 1 pass | 162 ms · 1 pass |
| single agg, cached | 1406 ms · 1 pass | 169 ms · 1 pass |
| multi agg, raw | 953 ms · 5 passes | 183 ms · 1 pass |
| multi agg, cached | 3859 ms · 5 passes | 180 ms · 1 pass |

All 1688 tests pass; lint and tsc clean.