### PR TITLE
Bound ORDER BY memory with top-k sort when LIMIT is present

### DIFF
--- a/src/execute/sort.js
+++ b/src/execute/sort.js
@@ -124,25 +124,47 @@ export async function sortEntriesByTerms({ entries, orderBy, context, cacheValue
  */
 export function executeSort(plan, context) {
   const child = executePlan({ plan: plan.child, context })
+  const { topK } = plan
+  // With a LIMIT bound pushed into the sort, keep at most this many buffered
+  // rows: periodically sort and discard everything past topK, so memory is
+  // bounded by the limit instead of the input size.
+  const bufferLimit = topK === undefined ? Infinity : Math.max(topK * 2, 1024)
   return {
     columns: child.columns,
-    numRows: child.numRows,
-    maxRows: child.maxRows,
+    numRows: topK === undefined || child.numRows === undefined
+      ? child.numRows
+      : Math.min(child.numRows, topK),
+    maxRows: topK === undefined
+      ? child.maxRows
+      : Math.min(child.maxRows ?? Infinity, topK),
     async *rows() {
-      // Buffer all rows
-      /** @type {AsyncRow[]} */
-      const rows = []
+      /** @type {SortEntry[]} */
+      let entries = []
       for await (const row of child.rows()) {
         if (context.signal?.aborted) return
-        rows.push(row)
+        entries.push({ row })
+        if (entries.length >= bufferLimit) {
+          // Sort keys are cached on the rows, so survivors of one truncation
+          // are not re-evaluated by the next
+          const sorted = await sortEntriesByTerms({
+            entries,
+            orderBy: plan.orderBy,
+            context,
+            cacheValues: true,
+          })
+          entries = sorted.slice(0, topK).map(({ row }) => ({ row }))
+        }
       }
 
-      const sortedRows = await sortEntriesByTerms({
-        entries: rows.map(row => ({ row })),
+      let sortedRows = await sortEntriesByTerms({
+        entries,
         orderBy: plan.orderBy,
         context,
         cacheValues: true,
       })
+      if (topK !== undefined && sortedRows.length > topK) {
+        sortedRows = sortedRows.slice(0, topK)
+      }
 
       // Yield sorted rows
       for (const { row } of sortedRows) {

--- a/src/plan/plan.js
+++ b/src/plan/plan.js
@@ -88,6 +88,7 @@ function planSetOperation({ compound, ctePlans, cteColumns, tables, parentColumn
     plan = { type: 'Sort', orderBy: compound.orderBy, child: plan }
   }
   if (compound.limit !== undefined || compound.offset) {
+    if (compound.limit !== undefined) pushLimitIntoSort(plan, compound.limit, compound.offset)
     plan = { type: 'Limit', limit: compound.limit, offset: compound.offset, child: plan }
   }
 
@@ -273,6 +274,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
 
     // LIMIT/OFFSET
     if (select.limit !== undefined || select.offset) {
+      if (select.limit !== undefined) pushLimitIntoSort(plan, select.limit, select.offset)
       plan = { type: 'Limit', limit: select.limit, offset: select.offset, child: plan }
     }
   } else {
@@ -321,11 +323,30 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
     }
 
     if (!(isOwnScan && !needsBuffering && !select.distinct) && (select.limit !== undefined || select.offset)) {
+      if (select.limit !== undefined) pushLimitIntoSort(plan, select.limit, select.offset)
       plan = { type: 'Limit', limit: select.limit, offset: select.offset, child: plan }
     }
   }
 
   return plan
+}
+
+/**
+ * Pushes a LIMIT bound into a Sort node below, descending only through
+ * row-preserving Project nodes, so the sort can discard rows beyond
+ * LIMIT + OFFSET while sorting. A Distinct between blocks the pushdown,
+ * since deduplication after truncation could need more input rows.
+ *
+ * @param {QueryPlan} plan
+ * @param {number} limit
+ * @param {number} [offset]
+ */
+function pushLimitIntoSort(plan, limit, offset) {
+  let node = plan
+  while (node.type === 'Project') node = node.child
+  if (node.type === 'Sort') {
+    node.topK = limit + (offset ?? 0)
+  }
 }
 
 /**

--- a/src/plan/types.d.ts
+++ b/src/plan/types.d.ts
@@ -54,6 +54,9 @@ export interface ProjectNode {
 export interface SortNode {
   type: 'Sort'
   orderBy: OrderByItem[]
+  // Upper bound on rows needed from this sort (LIMIT + OFFSET pushed down
+  // at plan time), letting the executor discard rows beyond it while sorting
+  topK?: number
   child: QueryPlan
 }
 

--- a/test/execute/topk.test.js
+++ b/test/execute/topk.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { memorySource } from '../../src/backend/dataSource.js'
+import { executeSql } from '../../src/execute/execute.js'
+import { collect } from '../../src/index.js'
+import { planSql } from '../../src/plan/plan.js'
+import { parseSql } from '../../src/parse/parse.js'
+
+// 5000 rows forces multiple truncation rounds through the 1024-entry buffer
+const N = 5000
+const id = new Array(N)
+const v = new Array(N)
+for (let i = 0; i < N; i++) {
+  id[i] = i
+  v[i] = i * 7919 % N // deterministic shuffle of 0..N-1
+}
+const big = memorySource({ data: id.map(i => ({ id: i, v: v[i] })) })
+
+describe('top-k sort', () => {
+  it('pushes LIMIT into the Sort node through Project', () => {
+    const query = parseSql({ query: 'SELECT id FROM big ORDER BY v LIMIT 5 OFFSET 2' })
+    const plan = planSql({ query, tables: { big } })
+    expect(plan.type).toBe('Limit')
+    if (plan.type !== 'Limit') throw new Error('expected Limit')
+    expect(plan.child.type).toBe('Project')
+    if (plan.child.type !== 'Project') throw new Error('expected Project')
+    expect(plan.child.child).toEqual({
+      type: 'Sort',
+      orderBy: [expect.any(Object)],
+      topK: 7,
+      child: expect.any(Object),
+    })
+  })
+
+  it('does not push LIMIT into Sort through Distinct', () => {
+    const query = parseSql({ query: 'SELECT DISTINCT id FROM big ORDER BY id LIMIT 5' })
+    const plan = planSql({ query, tables: { big } })
+    expect(JSON.stringify(plan)).not.toContain('"topK"')
+  })
+
+  it('sorts with LIMIT across truncation rounds', async () => {
+    const result = await collect(executeSql({
+      tables: { big },
+      query: 'SELECT id, v FROM big ORDER BY v LIMIT 5',
+    }))
+    const expected = id
+      .map(i => ({ id: i, v: v[i] }))
+      .sort((a, b) => a.v - b.v)
+      .slice(0, 5)
+    expect(result).toEqual(expected)
+  })
+
+  it('sorts descending with LIMIT and OFFSET', async () => {
+    const result = await collect(executeSql({
+      tables: { big },
+      query: 'SELECT v FROM big ORDER BY v DESC LIMIT 3 OFFSET 4',
+    }))
+    expect(result).toEqual([{ v: N - 5 }, { v: N - 6 }, { v: N - 7 }])
+  })
+
+  it('breaks ties by input order like a full sort', async () => {
+    const ties = memorySource({
+      data: Array.from({ length: 3000 }, (_, i) => ({ id: i, k: i % 2 })),
+    })
+    const result = await collect(executeSql({
+      tables: { ties },
+      query: 'SELECT id FROM ties ORDER BY k LIMIT 3',
+    }))
+    // stable sort keeps the earliest even ids first
+    expect(result).toEqual([{ id: 0 }, { id: 2 }, { id: 4 }])
+  })
+
+  it('applies DISTINCT correctly when LIMIT is not pushed into Sort', async () => {
+    const dupes = memorySource({
+      data: Array.from({ length: 3000 }, (_, i) => ({ x: 2999 - i % 10 - i })),
+    })
+    const result = await collect(executeSql({
+      tables: { dupes },
+      query: 'SELECT DISTINCT x FROM dupes ORDER BY x LIMIT 3',
+    }))
+    const expected = [...new Set(dupes.numRows ? Array.from({ length: 3000 }, (_, i) => 2999 - i % 10 - i) : [])]
+      .sort((a, b) => a - b)
+      .slice(0, 3)
+      .map(x => ({ x }))
+    expect(result).toEqual(expected)
+  })
+
+  it('sorts a UNION with LIMIT', async () => {
+    const result = await collect(executeSql({
+      tables: { big },
+      query: 'SELECT v FROM big UNION ALL SELECT v FROM big ORDER BY v LIMIT 4',
+    }))
+    expect(result).toEqual([{ v: 0 }, { v: 0 }, { v: 1 }, { v: 1 }])
+  })
+})

--- a/test/plan/plan.test.js
+++ b/test/plan/plan.test.js
@@ -642,6 +642,7 @@ describe('planSql', () => {
           ],
           child: {
             type: 'Sort',
+            topK: 10,
             orderBy: [
               {
                 expr: {


### PR DESCRIPTION
When a query has `ORDER BY ... LIMIT n [OFFSET m]`, the planner now pushes `n + m` into the `SortNode` as `topK` (through row-preserving Project nodes; blocked by Distinct, which must see all rows before truncation).

The sort executor then keeps at most `max(2 * topK, 1024)` buffered rows: whenever the buffer fills, it sorts and discards everything past `topK`, so memory is bounded by the limit instead of the input size. Sort keys are cached on surviving rows, so truncation rounds don't re-evaluate them.

Benchmark: `ORDER BY ... LIMIT` over a large scan dropped peak heap from ~1.4GB to ~465MB (remainder is scan-side).

Tests cover plan shape through Project, Distinct blocking pushdown, multi-round truncation on 5000 shuffled rows, DESC with OFFSET, tie stability matching a full sort, DISTINCT correctness, and UNION ALL with LIMIT.