### PR TITLE
Introduce internal batch execution

### DIFF
--- a/src/backend/batch.js
+++ b/src/backend/batch.js
@@ -27,6 +27,21 @@ export function selectedRowCount(selection) {
 }
 
 /**
+ * Creates base-aligned ordinal values for the rows in a selection.
+ *
+ * @param {RowSelection} selection
+ * @returns {ColumnVector}
+ */
+export function selectionOrdinals(selection) {
+  const values = new Uint32Array(selection.length)
+  const length = selectedRowCount(selection)
+  for (let ordinal = 0; ordinal < length; ordinal++) {
+    values[selectionIndexAt(selection, ordinal)] = ordinal
+  }
+  return { type: 'typed', values, length: selection.length }
+}
+
+/**
  * Composes a selection over an already-selected domain with the selection
  * that produced that domain.
  *
@@ -152,7 +167,12 @@ export function readBatchColumn({ batch, columnIndex, selection = batch.selectio
 
   const result = column.type === 'source'
     ? column.read({ selection, signal })
-    : column.evaluate({ batch: column.input, selection, signal })
+    : column.evaluate({
+      batch: column.input,
+      selection,
+      signal,
+      rowOrdinals: selectVector(column.rowOrdinals, selection),
+    })
   const validated = validateColumnResult(result, selectedRowCount(selection))
   if (validated instanceof Promise) {
     const settled = validated.then(function cacheResolved(vector) {

--- a/src/backend/batch.js
+++ b/src/backend/batch.js
@@ -6,9 +6,6 @@
 /** @type {WeakMap<AsyncBatch, Map<number, Map<RowSelection, { resolved?: ColumnVector, pending: Map<AbortSignal | undefined, Promise<ColumnVector>> }>>>} */
 const batchCache = new WeakMap()
 
-/** @type {WeakMap<RowSelection, Uint32Array | number[]>} */
-const selectionCache = new WeakMap()
-
 /**
  * Returns the number of selected rows.
  *
@@ -18,12 +15,7 @@ const selectionCache = new WeakMap()
 export function selectedRowCount(selection) {
   if (selection.type === 'all') return selection.length
   if (selection.type === 'range') return selection.end - selection.start
-  if (selection.type === 'ranges') {
-    const ends = endsForRanges(selection)
-    return ends.length === 0 ? 0 : ends[ends.length - 1]
-  }
-  if (selection.type === 'indices') return selection.indices.length
-  return indicesForBitmap(selection).length
+  return selection.indices.length
 }
 
 /**
@@ -62,16 +54,6 @@ export function composeSelections(outer, inner) {
       type: 'range',
       start: outer.start + inner.start,
       end: outer.start + inner.end,
-      length: outer.length,
-    }
-  }
-
-  if (outer.type === 'range' && inner.type === 'ranges') {
-    return {
-      type: 'ranges',
-      ranges: inner.ranges.map(function shiftRange(range) {
-        return { start: outer.start + range.start, end: outer.start + range.end }
-      }),
       length: outer.length,
     }
   }
@@ -140,11 +122,13 @@ export function selectVector(vector, selection) {
  */
 export function readBatchColumn({ batch, columnIndex, selection = batch.selection, signal }) {
   const column = batch.columns[columnIndex]
-  if (!column) throw new RangeError(`Column index ${columnIndex} is outside batch schema`)
+  if (!column) throw new RangeError(`Column index ${columnIndex} is outside batch columns`)
   if (selection.length !== batch.selection.length) {
     throw new Error(`Selection length ${selection.length} does not match batch length ${batch.selection.length}`)
   }
-  if (column.type === 'loaded') return selectVector(column.vector, selection)
+  if (column.type !== 'source' && column.type !== 'computed') {
+    return selectVector(column, selection)
+  }
 
   let batchResults = batchCache.get(batch)
   if (!batchResults) {
@@ -167,10 +151,11 @@ export function readBatchColumn({ batch, columnIndex, selection = batch.selectio
 
   const result = column.type === 'source'
     ? column.read({ selection, signal })
-    : column.evaluate({
+    : column.expression.evaluate({
       batch: column.input,
       selection,
       signal,
+      rowOffset: column.rowOffset,
       rowOrdinals: selectVector(column.rowOrdinals, selection),
     })
   const validated = validateColumnResult(result, selectedRowCount(selection))
@@ -200,7 +185,7 @@ export function readBatchColumn({ batch, columnIndex, selection = batch.selectio
 export function selectBatch(batch, selection) {
   const composed = composeSelections(batch.selection, selection)
   return {
-    schema: batch.schema,
+    columnNames: batch.columnNames,
     selection: composed,
     columns: batch.columns,
   }
@@ -220,65 +205,7 @@ function selectionIndexAt(selection, index) {
   }
   if (selection.type === 'all') return index
   if (selection.type === 'range') return selection.start + index
-  if (selection.type === 'indices') return selection.indices[index]
-  if (selection.type === 'ranges') {
-    const ends = endsForRanges(selection)
-    let low = 0
-    let high = ends.length
-    while (low < high) {
-      const middle = low + Math.floor((high - low) / 2)
-      if (index < ends[middle]) high = middle
-      else low = middle + 1
-    }
-    const previousEnd = low === 0 ? 0 : ends[low - 1]
-    const range = selection.ranges[low]
-    return range.start + index - previousEnd
-  } else return indicesForBitmap(selection)[index]
-}
-
-/**
- * Returns the cached cumulative selected-row endpoint for each range.
- *
- * @param {Extract<RowSelection, { type: 'ranges' }>} selection
- * @returns {number[]}
- */
-function endsForRanges(selection) {
-  const cached = selectionCache.get(selection)
-  if (Array.isArray(cached)) return cached
-  const ends = []
-  let count = 0
-  for (const range of selection.ranges) {
-    count += range.end - range.start
-    ends.push(count)
-  }
-  selectionCache.set(selection, ends)
-  return ends
-}
-
-/**
- * Builds the positional index for a bitmap once, avoiding a full bitmap scan
- * for every value read through a selected vector.
- *
- * @param {Extract<RowSelection, { type: 'bitmap' }>} selection
- * @returns {Uint32Array}
- */
-function indicesForBitmap(selection) {
-  const cached = selectionCache.get(selection)
-  if (cached instanceof Uint32Array) return cached
-  if (selection.values.length !== selection.length) {
-    throw new Error(`Bitmap length ${selection.values.length} does not match selection length ${selection.length}`)
-  }
-  let count = 0
-  for (const value of selection.values) {
-    if (value) count++
-  }
-  const indices = new Uint32Array(count)
-  let selectedIndex = 0
-  for (let index = 0; index < selection.values.length; index++) {
-    if (selection.values[index]) indices[selectedIndex++] = index
-  }
-  selectionCache.set(selection, indices)
-  return indices
+  return selection.indices[index]
 }
 
 /**

--- a/src/backend/batch.js
+++ b/src/backend/batch.js
@@ -1,0 +1,291 @@
+/**
+ * @import { AsyncBatch, ColumnResult, ColumnVector, ReadBatchColumnOptions, RowSelection } from '../internalTypes.js'
+ * @import { SqlPrimitive } from '../types.js'
+ */
+
+/** @type {WeakMap<AsyncBatch, Map<number, Map<RowSelection, { resolved?: ColumnVector, pending: Map<AbortSignal | undefined, Promise<ColumnVector>> }>>>} */
+const batchCache = new WeakMap()
+
+/** @type {WeakMap<RowSelection, Uint32Array | number[]>} */
+const selectionCache = new WeakMap()
+
+/**
+ * Returns the number of selected rows.
+ *
+ * @param {RowSelection} selection
+ * @returns {number}
+ */
+export function selectedRowCount(selection) {
+  if (selection.type === 'all') return selection.length
+  if (selection.type === 'range') return selection.end - selection.start
+  if (selection.type === 'ranges') {
+    const ends = endsForRanges(selection)
+    return ends.length === 0 ? 0 : ends[ends.length - 1]
+  }
+  if (selection.type === 'indices') return selection.indices.length
+  return indicesForBitmap(selection).length
+}
+
+/**
+ * Composes a selection over an already-selected domain with the selection
+ * that produced that domain.
+ *
+ * @param {RowSelection} outer - selection over the original base domain
+ * @param {RowSelection} inner - selection over the rows selected by `outer`
+ * @returns {RowSelection}
+ */
+export function composeSelections(outer, inner) {
+  const outerCount = selectedRowCount(outer)
+  if (inner.length !== outerCount) {
+    throw new Error(`Cannot compose selection of length ${inner.length} over ${outerCount} rows`)
+  }
+  if (inner.type === 'all') return outer
+  if (outer.type === 'all') return { ...inner, length: outer.length }
+
+  if (outer.type === 'range' && inner.type === 'range') {
+    return {
+      type: 'range',
+      start: outer.start + inner.start,
+      end: outer.start + inner.end,
+      length: outer.length,
+    }
+  }
+
+  if (outer.type === 'range' && inner.type === 'ranges') {
+    return {
+      type: 'ranges',
+      ranges: inner.ranges.map(function shiftRange(range) {
+        return { start: outer.start + range.start, end: outer.start + range.end }
+      }),
+      length: outer.length,
+    }
+  }
+
+  const indices = new Uint32Array(selectedRowCount(inner))
+  for (let i = 0; i < indices.length; i++) {
+    indices[i] = selectionIndexAt(outer, selectionIndexAt(inner, i))
+  }
+  return { type: 'indices', indices, length: outer.length }
+}
+
+/**
+ * Reads one logical value from a vector.
+ *
+ * @param {ColumnVector} vector
+ * @param {number} index
+ * @returns {SqlPrimitive}
+ */
+export function valueAt(vector, index) {
+  if (!Number.isInteger(index) || index < 0 || index >= vector.length) {
+    throw new RangeError(`Column index ${index} is outside vector length ${vector.length}`)
+  }
+  if (vector.type === 'values') return vector.values[index]
+  if (vector.type === 'typed') {
+    if (vector.validity && vector.validity[index] === 0) return null
+    return vector.values[index]
+  }
+  if (vector.type === 'constant') return vector.value
+  return valueAt(vector.source, selectionIndexAt(vector.selection, index))
+}
+
+/**
+ * Creates a zero-copy view of a vector through a row selection.
+ *
+ * @param {ColumnVector} vector
+ * @param {RowSelection} selection
+ * @returns {ColumnVector}
+ */
+export function selectVector(vector, selection) {
+  if (selection.length !== vector.length) {
+    throw new Error(`Cannot select ${selection.length} rows from vector length ${vector.length}`)
+  }
+  if (selection.type === 'all') return vector
+  if (vector.type === 'selected') {
+    const composed = composeSelections(vector.selection, selection)
+    return {
+      type: 'selected',
+      source: vector.source,
+      selection: composed,
+      length: selectedRowCount(composed),
+    }
+  }
+  return {
+    type: 'selected',
+    source: vector,
+    selection,
+    length: selectedRowCount(selection),
+  }
+}
+
+/**
+ * Resolves one batch column for an effective selection.
+ *
+ * @param {ReadBatchColumnOptions} options
+ * @returns {ColumnResult}
+ */
+export function readBatchColumn({ batch, columnIndex, selection = batch.selection, signal }) {
+  const column = batch.columns[columnIndex]
+  if (!column) throw new RangeError(`Column index ${columnIndex} is outside batch schema`)
+  if (selection.length !== batch.selection.length) {
+    throw new Error(`Selection length ${selection.length} does not match batch length ${batch.selection.length}`)
+  }
+  if (column.type === 'loaded') return selectVector(column.vector, selection)
+
+  let batchResults = batchCache.get(batch)
+  if (!batchResults) {
+    batchResults = new Map()
+    batchCache.set(batch, batchResults)
+  }
+  let columnResults = batchResults.get(columnIndex)
+  if (!columnResults) {
+    columnResults = new Map()
+    batchResults.set(columnIndex, columnResults)
+  }
+  let cache = columnResults.get(selection)
+  if (!cache) {
+    cache = { pending: new Map() }
+    columnResults.set(selection, cache)
+  }
+  const pending = cache.pending.get(signal)
+  if (pending) return pending
+  if (cache.resolved) return cache.resolved
+
+  const result = column.type === 'source'
+    ? column.read({ selection, signal })
+    : column.evaluate({ batch: column.input, selection, signal })
+  const validated = validateColumnResult(result, selectedRowCount(selection))
+  if (validated instanceof Promise) {
+    const settled = validated.then(function cacheResolved(vector) {
+      cache.pending.delete(signal)
+      cache.resolved ??= vector
+      return vector
+    }, function evictRejected(error) {
+      cache.pending.delete(signal)
+      throw error
+    })
+    cache.pending.set(signal, settled)
+    return settled
+  }
+  cache.resolved = validated
+  return validated
+}
+
+/**
+ * Selects rows from a batch without reading or copying its columns.
+ *
+ * @param {AsyncBatch} batch
+ * @param {RowSelection} selection - selection over the batch's current rows
+ * @returns {AsyncBatch}
+ */
+export function selectBatch(batch, selection) {
+  const composed = composeSelections(batch.selection, selection)
+  return {
+    schema: batch.schema,
+    selection: composed,
+    columns: batch.columns,
+  }
+}
+
+/**
+ * Returns a base-domain row index for a logical selected-row index.
+ *
+ * @param {RowSelection} selection
+ * @param {number} index
+ * @returns {number}
+ */
+function selectionIndexAt(selection, index) {
+  const count = selectedRowCount(selection)
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new RangeError(`Selection index ${index} is outside selected length ${count}`)
+  }
+  if (selection.type === 'all') return index
+  if (selection.type === 'range') return selection.start + index
+  if (selection.type === 'indices') return selection.indices[index]
+  if (selection.type === 'ranges') {
+    const ends = endsForRanges(selection)
+    let low = 0
+    let high = ends.length
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2)
+      if (index < ends[middle]) high = middle
+      else low = middle + 1
+    }
+    const previousEnd = low === 0 ? 0 : ends[low - 1]
+    const range = selection.ranges[low]
+    return range.start + index - previousEnd
+  } else return indicesForBitmap(selection)[index]
+}
+
+/**
+ * Returns the cached cumulative selected-row endpoint for each range.
+ *
+ * @param {Extract<RowSelection, { type: 'ranges' }>} selection
+ * @returns {number[]}
+ */
+function endsForRanges(selection) {
+  const cached = selectionCache.get(selection)
+  if (Array.isArray(cached)) return cached
+  const ends = []
+  let count = 0
+  for (const range of selection.ranges) {
+    count += range.end - range.start
+    ends.push(count)
+  }
+  selectionCache.set(selection, ends)
+  return ends
+}
+
+/**
+ * Builds the positional index for a bitmap once, avoiding a full bitmap scan
+ * for every value read through a selected vector.
+ *
+ * @param {Extract<RowSelection, { type: 'bitmap' }>} selection
+ * @returns {Uint32Array}
+ */
+function indicesForBitmap(selection) {
+  const cached = selectionCache.get(selection)
+  if (cached instanceof Uint32Array) return cached
+  if (selection.values.length !== selection.length) {
+    throw new Error(`Bitmap length ${selection.values.length} does not match selection length ${selection.length}`)
+  }
+  let count = 0
+  for (const value of selection.values) {
+    if (value) count++
+  }
+  const indices = new Uint32Array(count)
+  let selectedIndex = 0
+  for (let index = 0; index < selection.values.length; index++) {
+    if (selection.values[index]) indices[selectedIndex++] = index
+  }
+  selectionCache.set(selection, indices)
+  return indices
+}
+
+/**
+ * Validates the resolved vector length without forcing synchronous column
+ * implementations through a promise.
+ *
+ * @param {ColumnResult} result
+ * @param {number} expectedLength
+ * @returns {ColumnResult}
+ */
+function validateColumnResult(result, expectedLength) {
+  if (result instanceof Promise) {
+    return result.then(function validateResolvedVector(vector) {
+      return validateVectorLength(vector, expectedLength)
+    })
+  }
+  return validateVectorLength(result, expectedLength)
+}
+
+/**
+ * @param {ColumnVector} vector
+ * @param {number} expectedLength
+ * @returns {ColumnVector}
+ */
+function validateVectorLength(vector, expectedLength) {
+  if (vector.length !== expectedLength) {
+    throw new Error(`Column returned ${vector.length} rows, expected ${expectedLength}`)
+  }
+  return vector
+}

--- a/src/backend/batchAdapters.js
+++ b/src/backend/batchAdapters.js
@@ -1,0 +1,186 @@
+import { readBatchColumn, selectVector, selectedRowCount, valueAt } from './batch.js'
+import { yieldToEventLoop } from '../execute/yield.js'
+
+/**
+ * @import { AsyncBatch, ColumnResult, ColumnVector, RelationSchema, RowsToBatchesOptions } from '../internalTypes.js'
+ * @import { AsyncCells, AsyncRow, SqlPrimitive } from '../types.js'
+ */
+
+const DEFAULT_BATCH_ROWS = 1024
+
+/**
+ * Materializes a legacy row stream into aligned batches. This is a source or
+ * public compatibility boundary, not an operator implementation strategy.
+ *
+ * @param {AsyncIterable<AsyncRow>} rows
+ * @param {RelationSchema} schema
+ * @param {RowsToBatchesOptions} [options]
+ * @yields {AsyncBatch}
+ */
+export async function* rowsToBatches(rows, schema, options) {
+  const batchRows = options?.batchRows ?? DEFAULT_BATCH_ROWS
+  if (!Number.isInteger(batchRows) || batchRows <= 0) {
+    throw new RangeError(`batchRows must be a positive integer, got ${batchRows}`)
+  }
+  const names = schema.fields.map(function fieldName(field) { return field.name })
+  let values = makeValueBuffers(names.length)
+  let rowCount = 0
+
+  for await (const row of rows) {
+    options?.signal?.throwIfAborted()
+    for (let columnIndex = 0; columnIndex < names.length; columnIndex++) {
+      const name = names[columnIndex]
+      values[columnIndex].push(await readRowCell(row, name))
+    }
+    rowCount++
+    if (rowCount === batchRows) {
+      yield loadedBatch(schema, values, rowCount)
+      values = makeValueBuffers(names.length)
+      rowCount = 0
+    }
+  }
+
+  if (rowCount > 0) yield loadedBatch(schema, values, rowCount)
+  options?.signal?.throwIfAborted()
+}
+
+/**
+ * Exposes batches through the legacy lazy-cell row interface. Column reads
+ * remain lazy and are memoized once per batch/selection by `readBatchColumn`.
+ *
+ * @param {AsyncIterable<AsyncBatch>} batches
+ * @param {AbortSignal} [signal]
+ * @yields {AsyncRow}
+ */
+export async function* batchesToRows(batches, signal) {
+  for await (const batch of batches) {
+    const columns = batch.schema.fields.map(function fieldName(field) { return field.name })
+    const loadedVectors = batch.columns.map(function loadedVector(column) {
+      return column.type === 'loaded'
+        ? selectVector(column.vector, batch.selection)
+        : undefined
+    })
+    const rowCount = selectedRowCount(batch.selection)
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      signal?.throwIfAborted()
+      /** @type {AsyncCells} */
+      const cells = {}
+      for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+        const currentColumn = columnIndex
+        const currentRow = rowIndex
+        const loadedVector = loadedVectors[columnIndex]
+        if (loadedVector) {
+          const value = valueAt(loadedVector, currentRow)
+          cells[columns[columnIndex]] = function readLoadedCell() {
+            return Promise.resolve(value)
+          }
+        } else {
+          cells[columns[columnIndex]] = async function readCell() {
+            const vector = await readBatchColumn({ batch, columnIndex: currentColumn, signal })
+            return valueAt(vector, currentRow)
+          }
+        }
+      }
+      yield { columns, cells }
+    }
+  }
+  signal?.throwIfAborted()
+}
+
+/**
+ * Collects batches directly into the existing object-row result shape without
+ * constructing compatibility `AsyncRow` values.
+ *
+ * @param {AsyncIterable<AsyncBatch>} batches
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<Record<string, SqlPrimitive>[]>}
+ */
+export async function collectBatches(batches, signal) {
+  /** @type {Record<string, SqlPrimitive>[]} */
+  const rows = []
+  for await (const batch of batches) {
+    const names = batch.schema.fields.map(function fieldName(field) { return field.name })
+    const results = batch.columns.map(function readColumn(_column, columnIndex) {
+      return readBatchColumn({ batch, columnIndex, signal })
+    })
+    const vectors = await resolveColumns(results)
+    const rowCount = selectedRowCount(batch.selection)
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      if (signal && rowIndex % 4000 === 0) {
+        if (rowIndex > 0) await yieldToEventLoop()
+        signal.throwIfAborted()
+      }
+      /** @type {Record<string, SqlPrimitive>} */
+      const row = {}
+      for (let columnIndex = 0; columnIndex < names.length; columnIndex++) {
+        row[names[columnIndex]] = valueAt(vectors[columnIndex], rowIndex)
+      }
+      rows.push(row)
+    }
+  }
+  signal?.throwIfAborted()
+  return rows
+}
+
+/**
+ * @param {AsyncRow} row
+ * @param {string} name
+ * @returns {Promise<SqlPrimitive>}
+ */
+async function readRowCell(row, name) {
+  if (row.resolved && Object.prototype.hasOwnProperty.call(row.resolved, name)) {
+    return row.resolved[name]
+  }
+  const cell = row.cells[name]
+  if (!cell) throw new Error(`Row does not contain column "${name}"`)
+  return await cell()
+}
+
+/**
+ * @param {number} count
+ * @returns {SqlPrimitive[][]}
+ */
+function makeValueBuffers(count) {
+  /** @type {SqlPrimitive[][]} */
+  const values = []
+  for (let i = 0; i < count; i++) values.push([])
+  return values
+}
+
+/**
+ * @param {RelationSchema} schema
+ * @param {SqlPrimitive[][]} values
+ * @param {number} rowCount
+ * @returns {AsyncBatch}
+ */
+function loadedBatch(schema, values, rowCount) {
+  return {
+    schema,
+    selection: { type: 'all', length: rowCount },
+    columns: values.map(function loadedColumn(columnValues) {
+      return {
+        type: 'loaded',
+        vector: { type: 'values', values: columnValues, length: rowCount },
+      }
+    }),
+  }
+}
+
+/**
+ * Avoids a promise boundary when every column is already loaded synchronously.
+ *
+ * @param {ColumnResult[]} results
+ * @returns {ColumnVector[] | Promise<ColumnVector[]>}
+ */
+function resolveColumns(results) {
+  if (results.some(function isPromise(result) { return result instanceof Promise })) {
+    return Promise.all(results)
+  }
+  /** @type {ColumnVector[]} */
+  const vectors = []
+  for (const result of results) {
+    if (result instanceof Promise) throw new Error('Unexpected asynchronous column result')
+    vectors.push(result)
+  }
+  return vectors
+}

--- a/src/backend/batchAdapters.js
+++ b/src/backend/batchAdapters.js
@@ -2,7 +2,7 @@ import { readBatchColumn, selectVector, selectedRowCount, valueAt } from './batc
 import { yieldToEventLoop } from '../execute/yield.js'
 
 /**
- * @import { AsyncBatch, ColumnResult, ColumnVector, RelationSchema, RowsToBatchesOptions } from '../internalTypes.js'
+ * @import { AsyncBatch, ColumnResult, ColumnVector, RowsToBatchesOptions } from '../internalTypes.js'
  * @import { AsyncCells, AsyncRow, SqlPrimitive } from '../types.js'
  */
 
@@ -13,34 +13,33 @@ const DEFAULT_BATCH_ROWS = 1024
  * public compatibility boundary, not an operator implementation strategy.
  *
  * @param {AsyncIterable<AsyncRow>} rows
- * @param {RelationSchema} schema
+ * @param {string[]} columnNames
  * @param {RowsToBatchesOptions} [options]
  * @yields {AsyncBatch}
  */
-export async function* rowsToBatches(rows, schema, options) {
+export async function* rowsToBatches(rows, columnNames, options) {
   const batchRows = options?.batchRows ?? DEFAULT_BATCH_ROWS
   if (!Number.isInteger(batchRows) || batchRows <= 0) {
     throw new RangeError(`batchRows must be a positive integer, got ${batchRows}`)
   }
-  const names = schema.fields.map(function fieldName(field) { return field.name })
-  let values = makeValueBuffers(names.length)
+  let values = makeValueBuffers(columnNames.length)
   let rowCount = 0
 
   for await (const row of rows) {
     options?.signal?.throwIfAborted()
-    for (let columnIndex = 0; columnIndex < names.length; columnIndex++) {
-      const name = names[columnIndex]
+    for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
+      const name = columnNames[columnIndex]
       values[columnIndex].push(await readRowCell(row, name))
     }
     rowCount++
     if (rowCount === batchRows) {
-      yield loadedBatch(schema, values, rowCount)
-      values = makeValueBuffers(names.length)
+      yield loadedBatch(columnNames, values, rowCount)
+      values = makeValueBuffers(columnNames.length)
       rowCount = 0
     }
   }
 
-  if (rowCount > 0) yield loadedBatch(schema, values, rowCount)
+  if (rowCount > 0) yield loadedBatch(columnNames, values, rowCount)
   options?.signal?.throwIfAborted()
 }
 
@@ -54,11 +53,10 @@ export async function* rowsToBatches(rows, schema, options) {
  */
 export async function* batchesToRows(batches, signal) {
   for await (const batch of batches) {
-    const columns = batch.schema.fields.map(function fieldName(field) { return field.name })
+    const columns = batch.columnNames
     const loadedVectors = batch.columns.map(function loadedVector(column) {
-      return column.type === 'loaded'
-        ? selectVector(column.vector, batch.selection)
-        : undefined
+      if (column.type === 'source' || column.type === 'computed') return undefined
+      return selectVector(column, batch.selection)
     })
     const rowCount = selectedRowCount(batch.selection)
     for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
@@ -99,7 +97,7 @@ export async function collectBatches(batches, signal) {
   /** @type {Record<string, SqlPrimitive>[]} */
   const rows = []
   for await (const batch of batches) {
-    const names = batch.schema.fields.map(function fieldName(field) { return field.name })
+    const names = batch.columnNames
     const results = batch.columns.map(function readColumn(_column, columnIndex) {
       return readBatchColumn({ batch, columnIndex, signal })
     })
@@ -148,20 +146,17 @@ function makeValueBuffers(count) {
 }
 
 /**
- * @param {RelationSchema} schema
+ * @param {string[]} columnNames
  * @param {SqlPrimitive[][]} values
  * @param {number} rowCount
  * @returns {AsyncBatch}
  */
-function loadedBatch(schema, values, rowCount) {
+function loadedBatch(columnNames, values, rowCount) {
   return {
-    schema,
+    columnNames,
     selection: { type: 'all', length: rowCount },
     columns: values.map(function loadedColumn(columnValues) {
-      return {
-        type: 'loaded',
-        vector: { type: 'values', values: columnValues, length: rowCount },
-      }
+      return { type: 'values', values: columnValues, length: rowCount }
     }),
   }
 }

--- a/src/execute/batchResults.js
+++ b/src/execute/batchResults.js
@@ -1,5 +1,7 @@
+import { batchesToRows } from '../backend/batchAdapters.js'
+
 /**
- * @import { InternalBatchResults } from '../internalTypes.js'
+ * @import { AsyncBatch, InternalBatchResults } from '../internalTypes.js'
  * @import { QueryResults } from '../types.js'
  */
 
@@ -7,14 +9,24 @@
 const internalBatches = new WeakMap()
 
 /**
- * Associates a public row result with its private batch execution path.
+ * Creates a public row result backed by private batches.
  *
- * @param {QueryResults} results
- * @param {InternalBatchResults} batchResults
+ * @param {object} options
+ * @param {string[]} options.columns
+ * @param {number} [options.numRows]
+ * @param {number} [options.maxRows]
+ * @param {() => AsyncIterable<AsyncBatch>} options.batches
+ * @param {AbortSignal} [options.signal]
  * @returns {QueryResults}
  */
-export function registerBatchResults(results, batchResults) {
-  internalBatches.set(results, batchResults)
+export function batchResult({ batches, signal, ...metadata }) {
+  const results = {
+    ...metadata,
+    rows() {
+      return batchesToRows(batches(), signal)
+    },
+  }
+  internalBatches.set(results, { columns: metadata.columns, batches, signal })
   return results
 }
 

--- a/src/execute/batchResults.js
+++ b/src/execute/batchResults.js
@@ -1,0 +1,29 @@
+/**
+ * @import { InternalBatchResults } from '../internalTypes.js'
+ * @import { QueryResults } from '../types.js'
+ */
+
+/** @type {WeakMap<QueryResults, InternalBatchResults>} */
+const internalBatches = new WeakMap()
+
+/**
+ * Associates a public row result with its private batch execution path.
+ *
+ * @param {QueryResults} results
+ * @param {InternalBatchResults} batchResults
+ * @returns {QueryResults}
+ */
+export function registerBatchResults(results, batchResults) {
+  internalBatches.set(results, batchResults)
+  return results
+}
+
+/**
+ * Returns the private batch execution path for a result, when available.
+ *
+ * @param {QueryResults} results
+ * @returns {InternalBatchResults | undefined}
+ */
+export function batchResultsFor(results) {
+  return internalBatches.get(results)
+}

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -1,0 +1,70 @@
+import { selectBatch, selectedRowCount } from '../backend/batch.js'
+
+/**
+ * @import { AsyncBatch, RelationSchema } from '../internalTypes.js'
+ */
+
+/**
+ * Applies LIMIT/OFFSET by composing batch selections and stops consuming the
+ * source as soon as the requested range is complete.
+ *
+ * @param {AsyncIterable<AsyncBatch>} batches
+ * @param {number} [limit]
+ * @param {number} [offset]
+ * @param {AbortSignal} [signal]
+ * @yields {AsyncBatch}
+ */
+export async function* limitBatches(batches, limit = Infinity, offset = 0, signal) {
+  if (limit <= 0) return
+  let skipped = 0
+  let yielded = 0
+  for await (const batch of batches) {
+    signal?.throwIfAborted()
+    const rowCount = selectedRowCount(batch.selection)
+    if (skipped + rowCount <= offset) {
+      skipped += rowCount
+      continue
+    }
+
+    const start = Math.max(0, offset - skipped)
+    const remaining = limit - yielded
+    const end = Math.min(rowCount, start + remaining)
+    if (end > start) {
+      if (start === 0 && end === rowCount) {
+        yield batch
+      } else {
+        yield selectBatch(batch, {
+          type: 'range',
+          start,
+          end,
+          length: rowCount,
+        })
+      }
+      yielded += end - start
+    }
+    skipped += rowCount
+    if (yielded >= limit) return
+  }
+  signal?.throwIfAborted()
+}
+
+/**
+ * Projects batches by positional column reference without reading or copying
+ * their vectors.
+ *
+ * @param {AsyncIterable<AsyncBatch>} batches
+ * @param {RelationSchema} schema
+ * @param {number[]} columnIndices
+ * @yields {AsyncBatch}
+ */
+export async function* projectBatches(batches, schema, columnIndices) {
+  for await (const batch of batches) {
+    yield {
+      schema,
+      selection: batch.selection,
+      columns: columnIndices.map(function selectColumn(columnIndex) {
+        return batch.columns[columnIndex]
+      }),
+    }
+  }
+}

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -1,4 +1,4 @@
-import { readBatchColumn, selectBatch, selectedRowCount, valueAt } from '../backend/batch.js'
+import { readBatchColumn, selectBatch, selectedRowCount, selectionOrdinals, valueAt } from '../backend/batch.js'
 import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
 
@@ -189,6 +189,8 @@ export async function* projectExpressionBatches(batches, schema, projections) {
   for await (const batch of batches) {
     const currentRowOffset = rowOffset
     rowOffset += selectedRowCount(batch.selection)
+    /** @type {ColumnVector | undefined} */
+    let rowOrdinals
     yield {
       schema,
       selection: batch.selection,
@@ -207,10 +209,12 @@ export async function* projectExpressionBatches(batches, schema, projections) {
             },
           }
         } else {
+          rowOrdinals ??= selectionOrdinals(batch.selection)
           column = {
             type: 'computed',
             input: batch,
             dependencies: projection.expression.dependencies,
+            rowOrdinals,
             evaluate(request) {
               return projection.expression.evaluate({ ...request, rowOffset: currentRowOffset })
             },

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -1,7 +1,7 @@
 import { selectBatch, selectedRowCount, valueAt } from '../backend/batch.js'
 
 /**
- * @import { AsyncBatch, ColumnVector, CompiledBatchExpression, RelationSchema, RowSelection } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchColumn, BatchProjection, ColumnVector, CompiledBatchExpression, RelationSchema, RowSelection } from '../internalTypes.js'
  */
 
 /**
@@ -75,21 +75,43 @@ export async function* filterBatches(batches, expression, signal) {
 }
 
 /**
- * Projects batches by positional column reference without reading or copying
- * their vectors.
+ * Projects batches into direct, constant, or lazily computed columns. A
+ * computed column retains the input batch that owns its dependency indices,
+ * so output columns remain schema-aligned without hidden dependency columns.
  *
  * @param {AsyncIterable<AsyncBatch>} batches
  * @param {RelationSchema} schema
- * @param {number[]} columnIndices
+ * @param {readonly BatchProjection[]} projections
  * @yields {AsyncBatch}
  */
-export async function* projectBatches(batches, schema, columnIndices) {
+export async function* projectExpressionBatches(batches, schema, projections) {
   for await (const batch of batches) {
     yield {
       schema,
       selection: batch.selection,
-      columns: columnIndices.map(function selectColumn(columnIndex) {
-        return batch.columns[columnIndex]
+      columns: projections.map(function projectColumn(projection) {
+        /** @type {BatchColumn} */
+        let column
+        if (projection.type === 'column') {
+          column = batch.columns[projection.columnIndex]
+        } else if (projection.type === 'constant') {
+          column = {
+            type: 'loaded',
+            vector: {
+              type: 'constant',
+              value: projection.value,
+              length: batch.selection.length,
+            },
+          }
+        } else {
+          column = {
+            type: 'computed',
+            input: batch,
+            dependencies: projection.expression.dependencies,
+            evaluate: projection.expression.evaluate,
+          }
+        }
+        return column
       }),
     }
   }

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -1,7 +1,7 @@
-import { selectBatch, selectedRowCount } from '../backend/batch.js'
+import { selectBatch, selectedRowCount, valueAt } from '../backend/batch.js'
 
 /**
- * @import { AsyncBatch, RelationSchema } from '../internalTypes.js'
+ * @import { AsyncBatch, ColumnVector, CompiledBatchExpression, RelationSchema, RowSelection } from '../internalTypes.js'
  */
 
 /**
@@ -49,6 +49,32 @@ export async function* limitBatches(batches, limit = Infinity, offset = 0, signa
 }
 
 /**
+ * Evaluates a predicate once per batch and composes the resulting selection
+ * without reading or copying payload columns.
+ *
+ * @param {AsyncIterable<AsyncBatch>} batches
+ * @param {CompiledBatchExpression} expression
+ * @param {AbortSignal} [signal]
+ * @yields {AsyncBatch}
+ */
+export async function* filterBatches(batches, expression, signal) {
+  for await (const batch of batches) {
+    signal?.throwIfAborted()
+    const result = expression.evaluate({ batch, selection: batch.selection, signal })
+    const predicate = result instanceof Promise ? await result : result
+    const rowCount = selectedRowCount(batch.selection)
+    const { selection, selectedCount } = predicateSelection(predicate, rowCount)
+    if (selectedCount === 0) continue
+    if (selectedCount === rowCount) {
+      yield batch
+    } else {
+      yield selectBatch(batch, selection)
+    }
+  }
+  signal?.throwIfAborted()
+}
+
+/**
  * Projects batches by positional column reference without reading or copying
  * their vectors.
  *
@@ -66,5 +92,27 @@ export async function* projectBatches(batches, schema, columnIndices) {
         return batch.columns[columnIndex]
       }),
     }
+  }
+}
+
+/**
+ * @param {ColumnVector} predicate
+ * @param {number} rowCount
+ * @returns {{ selection: Extract<RowSelection, { type: 'bitmap' }>, selectedCount: number }}
+ */
+function predicateSelection(predicate, rowCount) {
+  if (predicate.length !== rowCount) {
+    throw new Error(`Predicate returned ${predicate.length} rows, expected ${rowCount}`)
+  }
+  const values = new Uint8Array(rowCount)
+  let selectedCount = 0
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    if (!valueAt(predicate, rowIndex)) continue
+    values[rowIndex] = 1
+    selectedCount++
+  }
+  return {
+    selection: { type: 'bitmap', values, length: rowCount },
+    selectedCount,
   }
 }

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -7,6 +7,9 @@ import { yieldToEventLoop } from './yield.js'
  * @import { SqlPrimitive } from '../types.js'
  */
 
+const INITIAL_FILTER_WINDOW_ROWS = 256
+const MAX_FILTER_WINDOW_ROWS = 16_384
+
 /**
  * Applies LIMIT/OFFSET by composing batch selections and stops consuming the
  * source as soon as the requested range is complete.
@@ -52,29 +55,69 @@ export async function* limitBatches(batches, limit = Infinity, offset = 0, signa
 }
 
 /**
- * Evaluates a predicate once per batch and composes the resulting selection
- * without reading or copying payload columns.
+ * Evaluates a predicate in adaptive windows when a downstream limit can stop
+ * early, then composes selections without reading or copying payload columns.
  *
  * @param {AsyncIterable<AsyncBatch>} batches
  * @param {CompiledBatchExpression} expression
  * @param {AbortSignal} [signal]
+ * @param {number} [targetRows] - Matches needed by a downstream limit.
  * @yields {AsyncBatch}
  */
-export async function* filterBatches(batches, expression, signal) {
+export async function* filterBatches(batches, expression, signal, targetRows) {
   let rowOffset = 0
+  let matchedRows = 0
+  let windowRows = targetRows === undefined
+    ? Infinity
+    : Math.min(MAX_FILTER_WINDOW_ROWS, Math.max(INITIAL_FILTER_WINDOW_ROWS, targetRows))
   for await (const batch of batches) {
     signal?.throwIfAborted()
     const rowCount = selectedRowCount(batch.selection)
-    const result = expression.evaluate({ batch, selection: batch.selection, signal, rowOffset })
-    const predicate = result instanceof Promise ? await result : result
-    const { selection, selectedCount } = predicateSelection(predicate, rowCount)
-    rowOffset += rowCount
-    if (selectedCount === 0) continue
-    if (selectedCount === rowCount) {
-      yield batch
-    } else {
-      yield selectBatch(batch, selection)
+    let start = 0
+    while (start < rowCount) {
+      const remainingRows = rowCount - start
+      const requestedRows = targetRows !== undefined && matchedRows < targetRows
+        ? windowRows
+        : remainingRows
+      const end = Math.min(rowCount, start + requestedRows)
+      const windowBatch = start === 0 && end === rowCount
+        ? batch
+        : selectBatch(batch, {
+          type: 'range',
+          start,
+          end,
+          length: rowCount,
+        })
+      const windowRowCount = end - start
+      const result = expression.evaluate({
+        batch: windowBatch,
+        selection: windowBatch.selection,
+        signal,
+        rowOffset: rowOffset + start,
+      })
+      const predicate = result instanceof Promise ? await result : result
+      const { selection, selectedCount } = predicateSelection(predicate, windowRowCount)
+      start = end
+      matchedRows += selectedCount
+
+      if (targetRows !== undefined && matchedRows < targetRows) {
+        if (selectedCount === 0) {
+          windowRows = Math.min(MAX_FILTER_WINDOW_ROWS, windowRows * 2)
+        } else {
+          const remainingMatches = targetRows - matchedRows
+          const estimatedRows = Math.ceil(remainingMatches * windowRowCount / selectedCount * 1.25)
+          windowRows = Math.min(MAX_FILTER_WINDOW_ROWS, Math.max(INITIAL_FILTER_WINDOW_ROWS, estimatedRows))
+        }
+      }
+
+      if (selectedCount === 0) continue
+      if (selectedCount === windowRowCount) {
+        yield windowBatch
+      } else {
+        yield selectBatch(windowBatch, selection)
+      }
     }
+    rowOffset += rowCount
   }
   signal?.throwIfAborted()
 }

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -1,7 +1,10 @@
-import { selectBatch, selectedRowCount, valueAt } from '../backend/batch.js'
+import { readBatchColumn, selectBatch, selectedRowCount, valueAt } from '../backend/batch.js'
+import { keyify } from './utils.js'
+import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncBatch, BatchColumn, BatchProjection, ColumnVector, CompiledBatchExpression, RelationSchema, RowSelection } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchColumn, BatchProjection, ColumnResult, ColumnVector, CompiledBatchExpression, RelationSchema, RowSelection } from '../internalTypes.js'
+ * @import { SqlPrimitive } from '../types.js'
  */
 
 /**
@@ -75,6 +78,58 @@ export async function* filterBatches(batches, expression, signal) {
 }
 
 /**
+ * Removes duplicate rows while retaining zero-copy selections over the input
+ * batches. DISTINCT requires every output column as both a key and payload, so
+ * resolving all batch columns here does not introduce eager payload work.
+ *
+ * @param {AsyncIterable<AsyncBatch>} batches
+ * @param {AbortSignal} [signal]
+ * @yields {AsyncBatch}
+ */
+export async function* distinctBatches(batches, signal) {
+  const seen = new Set()
+  for await (const batch of batches) {
+    signal?.throwIfAborted()
+    const results = batch.columns.map(function readColumn(_column, columnIndex) {
+      return readBatchColumn({ batch, columnIndex, signal })
+    })
+    const resolved = resolveVectors(results)
+    const vectors = resolved instanceof Promise ? await resolved : resolved
+    const rowCount = selectedRowCount(batch.selection)
+    const indices = new Uint32Array(rowCount)
+    /** @type {SqlPrimitive[]} */
+    const row = new Array(vectors.length)
+    let selectedCount = 0
+
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      if (signal && rowIndex > 0 && rowIndex % 4000 === 0) {
+        await yieldToEventLoop()
+        signal.throwIfAborted()
+      }
+      for (let columnIndex = 0; columnIndex < vectors.length; columnIndex++) {
+        row[columnIndex] = valueAt(vectors[columnIndex], rowIndex)
+      }
+      const key = keyify(...row)
+      if (seen.has(key)) continue
+      seen.add(key)
+      indices[selectedCount++] = rowIndex
+    }
+
+    if (selectedCount === 0) continue
+    if (selectedCount === rowCount) {
+      yield batch
+    } else {
+      yield selectBatch(batch, {
+        type: 'indices',
+        indices: indices.subarray(0, selectedCount),
+        length: rowCount,
+      })
+    }
+  }
+  signal?.throwIfAborted()
+}
+
+/**
  * Projects batches into direct, constant, or lazily computed columns. A
  * computed column retains the input batch that owns its dependency indices,
  * so output columns remain schema-aligned without hidden dependency columns.
@@ -137,4 +192,21 @@ function predicateSelection(predicate, rowCount) {
     selection: { type: 'bitmap', values, length: rowCount },
     selectedCount,
   }
+}
+
+/**
+ * @param {ColumnResult[]} results
+ * @returns {ColumnVector[] | Promise<ColumnVector[]>}
+ */
+function resolveVectors(results) {
+  if (results.some(function isPromise(result) { return result instanceof Promise })) {
+    return Promise.all(results)
+  }
+  /** @type {ColumnVector[]} */
+  const vectors = []
+  for (const result of results) {
+    if (result instanceof Promise) throw new Error('Unexpected asynchronous column result')
+    vectors.push(result)
+  }
+  return vectors
 }

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -3,7 +3,7 @@ import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncBatch, BatchColumn, BatchProjection, ColumnResult, ColumnVector, CompiledBatchExpression, RelationSchema, RowSelection } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchColumn, BatchProjection, ColumnResult, ColumnVector, CompiledBatchExpression, RowSelection } from '../internalTypes.js'
  * @import { SqlPrimitive } from '../types.js'
  */
 
@@ -177,14 +177,14 @@ export async function* distinctBatches(batches, signal) {
 /**
  * Projects batches into direct, constant, or lazily computed columns. A
  * computed column retains the input batch that owns its dependency indices,
- * so output columns remain schema-aligned without hidden dependency columns.
+ * so output columns remain aligned without hidden dependency columns.
  *
  * @param {AsyncIterable<AsyncBatch>} batches
- * @param {RelationSchema} schema
+ * @param {string[]} columnNames
  * @param {readonly BatchProjection[]} projections
  * @yields {AsyncBatch}
  */
-export async function* projectExpressionBatches(batches, schema, projections) {
+export async function* projectExpressionBatches(batches, columnNames, projections) {
   let rowOffset = 0
   for await (const batch of batches) {
     const currentRowOffset = rowOffset
@@ -192,7 +192,7 @@ export async function* projectExpressionBatches(batches, schema, projections) {
     /** @type {ColumnVector | undefined} */
     let rowOrdinals
     yield {
-      schema,
+      columnNames,
       selection: batch.selection,
       columns: projections.map(function projectColumn(projection) {
         /** @type {BatchColumn} */
@@ -201,23 +201,18 @@ export async function* projectExpressionBatches(batches, schema, projections) {
           column = batch.columns[projection.columnIndex]
         } else if (projection.type === 'constant') {
           column = {
-            type: 'loaded',
-            vector: {
-              type: 'constant',
-              value: projection.value,
-              length: batch.selection.length,
-            },
+            type: 'constant',
+            value: projection.value,
+            length: batch.selection.length,
           }
         } else {
           rowOrdinals ??= selectionOrdinals(batch.selection)
           column = {
             type: 'computed',
             input: batch,
-            dependencies: projection.expression.dependencies,
+            expression: projection.expression,
+            rowOffset: currentRowOffset,
             rowOrdinals,
-            evaluate(request) {
-              return projection.expression.evaluate({ ...request, rowOffset: currentRowOffset })
-            },
           }
         }
         return column
@@ -229,21 +224,20 @@ export async function* projectExpressionBatches(batches, schema, projections) {
 /**
  * @param {ColumnVector} predicate
  * @param {number} rowCount
- * @returns {{ selection: Extract<RowSelection, { type: 'bitmap' }>, selectedCount: number }}
+ * @returns {{ selection: Extract<RowSelection, { type: 'indices' }>, selectedCount: number }}
  */
 function predicateSelection(predicate, rowCount) {
   if (predicate.length !== rowCount) {
     throw new Error(`Predicate returned ${predicate.length} rows, expected ${rowCount}`)
   }
-  const values = new Uint8Array(rowCount)
+  const indices = new Uint32Array(rowCount)
   let selectedCount = 0
   for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
     if (!valueAt(predicate, rowIndex)) continue
-    values[rowIndex] = 1
-    selectedCount++
+    indices[selectedCount++] = rowIndex
   }
   return {
-    selection: { type: 'bitmap', values, length: rowCount },
+    selection: { type: 'indices', indices: indices.subarray(0, selectedCount), length: rowCount },
     selectedCount,
   }
 }

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -61,12 +61,14 @@ export async function* limitBatches(batches, limit = Infinity, offset = 0, signa
  * @yields {AsyncBatch}
  */
 export async function* filterBatches(batches, expression, signal) {
+  let rowOffset = 0
   for await (const batch of batches) {
     signal?.throwIfAborted()
-    const result = expression.evaluate({ batch, selection: batch.selection, signal })
-    const predicate = result instanceof Promise ? await result : result
     const rowCount = selectedRowCount(batch.selection)
+    const result = expression.evaluate({ batch, selection: batch.selection, signal, rowOffset })
+    const predicate = result instanceof Promise ? await result : result
     const { selection, selectedCount } = predicateSelection(predicate, rowCount)
+    rowOffset += rowCount
     if (selectedCount === 0) continue
     if (selectedCount === rowCount) {
       yield batch
@@ -140,7 +142,10 @@ export async function* distinctBatches(batches, signal) {
  * @yields {AsyncBatch}
  */
 export async function* projectExpressionBatches(batches, schema, projections) {
+  let rowOffset = 0
   for await (const batch of batches) {
+    const currentRowOffset = rowOffset
+    rowOffset += selectedRowCount(batch.selection)
     yield {
       schema,
       selection: batch.selection,
@@ -163,7 +168,9 @@ export async function* projectExpressionBatches(batches, schema, projections) {
             type: 'computed',
             input: batch,
             dependencies: projection.expression.dependencies,
-            evaluate: projection.expression.evaluate,
+            evaluate(request) {
+              return projection.expression.evaluate({ ...request, rowOffset: currentRowOffset })
+            },
           }
         }
         return column

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -9,7 +9,7 @@ import { statementScope } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
 import { batchResultsFor, registerBatchResults } from './batchResults.js'
-import { filterBatches, limitBatches, projectBatches } from './batches.js'
+import { filterBatches, limitBatches, projectExpressionBatches } from './batches.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
 import { normalizeScanColumnResult } from './scanColumn.js'
 import { executeSort } from './sort.js'
@@ -18,7 +18,7 @@ import { executeWindow } from './window.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncBatch, ColumnVector, RelationSchema } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchProjection, ColumnVector, RelationSchema } from '../internalTypes.js'
  * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, ExecuteSqlOptions, ExprNode, IdentifierNode, QueryResults, SelectColumn, SqlPrimitive, Statement } from '../types.js'
  * @import { CountNode, DistinctNode, FilterNode, LimitNode, ProjectNode, QueryPlan, ScanNode, SetOperationNode, TableFunctionNode } from '../plan/types.js'
  */
@@ -574,14 +574,14 @@ function executeProject(plan, context) {
   )
 
   const childBatches = batchResultsFor(child)
-  const projection = childBatches && resolveable
-    ? simpleProjection(plan.columns, columns, child.columns, childBatches.schema)
+  const projection = childBatches
+    ? batchProjection(plan.columns, columns, child.columns, childBatches.schema)
     : undefined
   if (projection && childBatches) {
     const readChildBatches = childBatches.batches
     /** @returns {AsyncIterable<AsyncBatch>} */
     function makeBatches() {
-      return projectBatches(readChildBatches(), projection.schema, projection.columnIndices)
+      return projectExpressionBatches(readChildBatches(), projection.schema, projection.projections)
     }
     const results = {
       columns,
@@ -846,53 +846,75 @@ function unknownSchema(columns) {
 }
 
 /**
- * Resolves a simple star/identifier projection to positional batch columns.
+ * Compiles a projection to direct, constant, or computed batch columns.
  *
  * @param {SelectColumn[]} planColumns
  * @param {string[]} outputColumns
  * @param {string[]} childColumns
  * @param {RelationSchema} childSchema
- * @returns {{ schema: RelationSchema, columnIndices: number[] } | undefined}
+ * @returns {{ schema: RelationSchema, projections: BatchProjection[] } | undefined}
  */
-function simpleProjection(planColumns, outputColumns, childColumns, childSchema) {
-  /** @type {number[]} */
-  const columnIndices = []
+function batchProjection(planColumns, outputColumns, childColumns, childSchema) {
+  /** @type {BatchProjection[]} */
+  const projections = []
   for (const column of planColumns) {
     if (column.type === 'star') {
       const prefix = column.table ? `${column.table}.` : undefined
       for (let i = 0; i < childColumns.length; i++) {
-        if (!prefix || childColumns[i].startsWith(prefix)) columnIndices.push(i)
+        if (!prefix || childColumns[i].startsWith(prefix)) {
+          projections.push({ type: 'column', columnIndex: i })
+        }
       }
       continue
     }
 
-    if (column.expr.type !== 'identifier') return undefined
-    const identifier = column.expr
-    const sourceName = identifier.prefix
-      ? `${identifier.prefix}.${identifier.name}`
-      : identifier.name
-    let index = childColumns.indexOf(sourceName)
-    if (index < 0) {
-      const suffix = `.${identifier.name}`
-      const matches = childColumns
-        .map(function childColumn(name, childIndex) { return { name, childIndex } })
-        .filter(function suffixMatch(candidate) { return candidate.name.endsWith(suffix) })
-      if (matches.length !== 1) return undefined
-      index = matches[0].childIndex
+    if (column.expr.type === 'literal') {
+      projections.push({ type: 'constant', value: column.expr.value })
+      continue
     }
-    columnIndices.push(index)
+    if (column.expr.type === 'identifier') {
+      const index = identifierColumnIndex(column.expr, childColumns)
+      if (index === undefined) return undefined
+      projections.push({ type: 'column', columnIndex: index })
+      continue
+    }
+    const expression = compileBatchExpression({ expression: column.expr, schema: childSchema })
+    if (!expression) return undefined
+    projections.push({ type: 'expression', expression })
   }
-  if (columnIndices.length !== outputColumns.length) return undefined
+  if (projections.length !== outputColumns.length) return undefined
 
   return {
     schema: {
-      fields: columnIndices.map(function projectedField(childIndex, id) {
-        const field = childSchema.fields[childIndex]
-        return { ...field, id, name: outputColumns[id] }
+      fields: projections.map(function projectedField(projection, id) {
+        if (projection.type === 'column') {
+          const field = childSchema.fields[projection.columnIndex]
+          return { ...field, id, name: outputColumns[id] }
+        }
+        return { id, name: outputColumns[id], dataType: { type: 'unknown' }, nullable: true }
       }),
     },
-    columnIndices,
+    projections,
   }
+}
+
+/**
+ * @param {IdentifierNode} identifier
+ * @param {string[]} childColumns
+ * @returns {number | undefined}
+ */
+function identifierColumnIndex(identifier, childColumns) {
+  const sourceName = identifier.prefix
+    ? `${identifier.prefix}.${identifier.name}`
+    : identifier.name
+  const index = childColumns.indexOf(sourceName)
+  if (index >= 0) return index
+
+  const suffix = `.${identifier.name}`
+  const matches = childColumns
+    .map(function childColumn(name, childIndex) { return { name, childIndex } })
+    .filter(function suffixMatch(candidate) { return candidate.name.endsWith(suffix) })
+  return matches.length === 1 ? matches[0].childIndex : undefined
 }
 
 /**

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -551,6 +551,29 @@ async function* limitRows(rows, limit = Infinity, offset = 0, signal) {
  */
 function executeFilter(plan, context) {
   const child = executePlan({ plan: plan.child, context })
+  const childBatches = batchResultsFor(child)
+  const expression = childBatches
+    ? compileBatchExpression({ expression: plan.condition, schema: childBatches.schema })
+    : undefined
+  if (expression && childBatches) {
+    const readChildBatches = childBatches.batches
+    /** @returns {AsyncIterable<AsyncBatch>} */
+    function makeBatches() {
+      return filterBatches(readChildBatches(), expression, context.signal)
+    }
+    const results = {
+      columns: child.columns,
+      maxRows: child.maxRows,
+      async *rows() {
+        yield* batchesToRows(makeBatches(), context.signal)
+      },
+    }
+    return registerBatchResults(results, {
+      schema: childBatches.schema,
+      batches: makeBatches,
+      signal: context.signal,
+    })
+  }
   return {
     columns: child.columns,
     maxRows: child.maxRows,

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -1,5 +1,4 @@
 import { memorySource } from '../backend/dataSource.js'
-import { batchesToRows } from '../backend/batchAdapters.js'
 import { derivedAlias } from '../expression/alias.js'
 import { compileBatchExpression } from '../expression/batch.js'
 import { evaluateExpr } from '../expression/evaluate.js'
@@ -8,7 +7,7 @@ import { planSql, planStatement } from '../plan/plan.js'
 import { statementScope } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
-import { batchResultsFor, registerBatchResults } from './batchResults.js'
+import { batchResult, batchResultsFor } from './batchResults.js'
 import { distinctBatches, filterBatches, limitBatches, projectExpressionBatches } from './batches.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
 import { normalizeScanColumnResult } from './scanColumn.js'
@@ -18,7 +17,7 @@ import { executeWindow } from './window.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncBatch, BatchProjection, ColumnVector, RelationSchema } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchProjection, ColumnVector } from '../internalTypes.js'
  * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, ExecuteSqlOptions, ExprNode, IdentifierNode, QueryResults, SelectColumn, SqlPrimitive, Statement } from '../types.js'
  * @import { CountNode, DistinctNode, FilterNode, LimitNode, ProjectNode, QueryPlan, ScanNode, SetOperationNode, TableFunctionNode } from '../plan/types.js'
  */
@@ -299,18 +298,18 @@ export function executeScan(plan, context, existingColumnResult) {
   if (columnResult && scanColumnOptions) {
     const column = plan.hints.columns[0]
     const scanRows = computeScanRows(table.numRows, plan.hints.limit, plan.hints.offset)
-    const schema = unknownSchema([column])
+    const columns = [column]
     const appliedLimitOffset = plan.hints.where
       ? false
       : columnResult.appliedLimitOffset
     const residualFilter = plan.hints.where && !columnResult.appliedWhere
-      ? compileBatchExpression({ expression: plan.hints.where, schema })
+      ? compileBatchExpression(plan.hints.where, columns)
       : undefined
 
     /** @returns {AsyncIterable<AsyncBatch>} */
     function makeBatches() {
       /** @type {AsyncIterable<AsyncBatch>} */
-      let batches = columnBatches(columnResult.chunks(), schema, signal)
+      let batches = columnBatches(columnResult.chunks(), columns, signal)
       if (residualFilter) {
         const targetRows = plan.hints.limit === undefined
           ? undefined
@@ -324,15 +323,20 @@ export function executeScan(plan, context, existingColumnResult) {
     }
 
     const canUseBatches = !plan.hints.where || columnResult.appliedWhere || residualFilter !== undefined
-    const results = {
-      columns: [column],
-      numRows: plan.hints.where ? undefined : scanRows,
+    if (canUseBatches) {
+      return batchResult({
+        columns,
+        numRows: plan.hints.where ? undefined : scanRows,
+        maxRows: scanRows,
+        batches: makeBatches,
+        signal,
+      })
+    }
+    return {
+      columns,
+      numRows: undefined,
       maxRows: scanRows,
       async *rows() {
-        if (canUseBatches) {
-          yield* batchesToRows(makeBatches(), signal)
-          return
-        }
         const columns = [column]
         let result = (async function* () {
           // Creating the chunk stream may itself start I/O, so leave it until
@@ -349,9 +353,7 @@ export function executeScan(plan, context, existingColumnResult) {
           }
         })()
 
-        if (!columnResult.appliedWhere && plan.hints.where) {
-          result = filterRows(result, plan.hints.where, context, plan.hints.limit)
-        }
+        result = filterRows(result, plan.hints.where, context, plan.hints.limit)
         // Filtered LIMIT/OFFSET was intentionally not passed to scanColumn.
         if (!appliedLimitOffset && hasLimitOffset) {
           result = limitRows(result, plan.hints.limit, plan.hints.offset, signal)
@@ -363,8 +365,6 @@ export function executeScan(plan, context, existingColumnResult) {
         signal?.throwIfAborted()
       },
     }
-    if (!canUseBatches) return results
-    return registerBatchResults(results, { schema, batches: makeBatches, signal })
   }
 
   // do the scan
@@ -556,7 +556,7 @@ function executeFilter(plan, context) {
   const child = executePlan({ plan: plan.child, context })
   const childBatches = batchResultsFor(child)
   const expression = childBatches
-    ? compileBatchExpression({ expression: plan.condition, schema: childBatches.schema })
+    ? compileBatchExpression(plan.condition, childBatches.columns)
     : undefined
   if (expression && childBatches) {
     const readChildBatches = childBatches.batches
@@ -564,15 +564,9 @@ function executeFilter(plan, context) {
     function makeBatches() {
       return filterBatches(readChildBatches(), expression, context.signal)
     }
-    const results = {
+    return batchResult({
       columns: child.columns,
       maxRows: child.maxRows,
-      async *rows() {
-        yield* batchesToRows(makeBatches(), context.signal)
-      },
-    }
-    return registerBatchResults(results, {
-      schema: childBatches.schema,
       batches: makeBatches,
       signal: context.signal,
     })
@@ -601,24 +595,18 @@ function executeProject(plan, context) {
 
   const childBatches = batchResultsFor(child)
   const projection = childBatches
-    ? batchProjection(plan.columns, columns, child.columns, childBatches.schema)
+    ? batchProjection(plan.columns, columns, child.columns)
     : undefined
   if (projection && childBatches) {
     const readChildBatches = childBatches.batches
     /** @returns {AsyncIterable<AsyncBatch>} */
     function makeBatches() {
-      return projectExpressionBatches(readChildBatches(), projection.schema, projection.projections)
+      return projectExpressionBatches(readChildBatches(), columns, projection)
     }
-    const results = {
+    return batchResult({
       columns,
       numRows: child.numRows,
       maxRows: child.maxRows,
-      async *rows() {
-        yield* batchesToRows(makeBatches(), context.signal)
-      },
-    }
-    return registerBatchResults(results, {
-      schema: projection.schema,
       batches: makeBatches,
       signal: context.signal,
     })
@@ -719,15 +707,9 @@ function executeDistinct(plan, context) {
     function makeBatches() {
       return distinctBatches(readChildBatches(), context.signal)
     }
-    const results = {
+    return batchResult({
       columns: child.columns,
       maxRows: child.maxRows,
-      async *rows() {
-        yield* batchesToRows(makeBatches(), context.signal)
-      },
-    }
-    return registerBatchResults(results, {
-      schema: childBatches.schema,
       batches: makeBatches,
       signal: context.signal,
     })
@@ -797,16 +779,10 @@ function executeLimit(plan, context) {
     function makeBatches() {
       return limitBatches(readChildBatches(), plan.limit, plan.offset, context.signal)
     }
-    const results = {
+    return batchResult({
       columns: child.columns,
       numRows: computeScanRows(child.numRows, plan.limit, plan.offset),
       maxRows: computeScanRows(child.maxRows, plan.limit, plan.offset),
-      async *rows() {
-        yield* batchesToRows(makeBatches(), context.signal)
-      },
-    }
-    return registerBatchResults(results, {
-      schema: childBatches.schema,
       batches: makeBatches,
       signal: context.signal,
     })
@@ -824,19 +800,19 @@ function executeLimit(plan, context) {
  * arrays. Each source chunk remains the async scheduling unit.
  *
  * @param {AsyncIterable<ArrayLike<SqlPrimitive>>} chunks
- * @param {RelationSchema} schema
+ * @param {string[]} columnNames
  * @param {AbortSignal} [signal]
  * @yields {AsyncBatch}
  */
-async function* columnBatches(chunks, schema, signal) {
+async function* columnBatches(chunks, columnNames, signal) {
   for await (const chunk of chunks) {
     signal?.throwIfAborted()
     const vector = vectorFromChunk(chunk)
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames,
       selection: { type: 'all', length: vector.length },
-      columns: [{ type: 'loaded', vector }],
+      columns: [vector],
     }
     yield batch
   }
@@ -880,27 +856,14 @@ function isNumericArray(values) {
 }
 
 /**
- * @param {string[]} columns
- * @returns {RelationSchema}
- */
-function unknownSchema(columns) {
-  return {
-    fields: columns.map(function unknownField(name, id) {
-      return { id, name, dataType: { type: 'unknown' }, nullable: true }
-    }),
-  }
-}
-
-/**
  * Compiles a projection to direct, constant, or computed batch columns.
  *
  * @param {SelectColumn[]} planColumns
  * @param {string[]} outputColumns
  * @param {string[]} childColumns
- * @param {RelationSchema} childSchema
- * @returns {{ schema: RelationSchema, projections: BatchProjection[] } | undefined}
+ * @returns {BatchProjection[] | undefined}
  */
-function batchProjection(planColumns, outputColumns, childColumns, childSchema) {
+function batchProjection(planColumns, outputColumns, childColumns) {
   /** @type {BatchProjection[]} */
   const projections = []
   for (const column of planColumns) {
@@ -924,12 +887,12 @@ function batchProjection(planColumns, outputColumns, childColumns, childSchema) 
         projections.push({ type: 'column', columnIndex: index })
         continue
       }
-      const expression = compileBatchExpression({ expression: column.expr, schema: childSchema })
+      const expression = compileBatchExpression(column.expr, childColumns)
       if (!expression) return undefined
       projections.push({ type: 'expression', expression })
       continue
     }
-    const expression = compileBatchExpression({ expression: column.expr, schema: childSchema })
+    const expression = compileBatchExpression(column.expr, childColumns)
     if (!expression) return undefined
     projections.push({ type: 'expression', expression })
   }
@@ -938,18 +901,7 @@ function batchProjection(planColumns, outputColumns, childColumns, childSchema) 
     projections[index] = projections[outputColumns.lastIndexOf(outputColumns[index])]
   }
 
-  return {
-    schema: {
-      fields: projections.map(function projectedField(projection, id) {
-        if (projection.type === 'column') {
-          const field = childSchema.fields[projection.columnIndex]
-          return { ...field, id, name: outputColumns[id] }
-        }
-        return { id, name: outputColumns[id], dataType: { type: 'unknown' }, nullable: true }
-      }),
-    },
-    projections,
-  }
+  return projections
 }
 
 /**

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -920,8 +920,13 @@ function batchProjection(planColumns, outputColumns, childColumns, childSchema) 
     }
     if (column.expr.type === 'identifier') {
       const index = identifierColumnIndex(column.expr, childColumns)
-      if (index === undefined) return undefined
-      projections.push({ type: 'column', columnIndex: index })
+      if (index !== undefined) {
+        projections.push({ type: 'column', columnIndex: index })
+        continue
+      }
+      const expression = compileBatchExpression({ expression: column.expr, schema: childSchema })
+      if (!expression) return undefined
+      projections.push({ type: 'expression', expression })
       continue
     }
     const expression = compileBatchExpression({ expression: column.expr, schema: childSchema })
@@ -929,6 +934,9 @@ function batchProjection(planColumns, outputColumns, childColumns, childSchema) 
     projections.push({ type: 'expression', expression })
   }
   if (projections.length !== outputColumns.length) return undefined
+  for (let index = 0; index < projections.length; index++) {
+    projections[index] = projections[outputColumns.lastIndexOf(outputColumns[index])]
+  }
 
   return {
     schema: {

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -312,7 +312,10 @@ export function executeScan(plan, context, existingColumnResult) {
       /** @type {AsyncIterable<AsyncBatch>} */
       let batches = columnBatches(columnResult.chunks(), schema, signal)
       if (residualFilter) {
-        batches = filterBatches(batches, residualFilter, signal)
+        const targetRows = plan.hints.limit === undefined
+          ? undefined
+          : plan.hints.limit + (plan.hints.offset ?? 0)
+        batches = filterBatches(batches, residualFilter, signal, targetRows)
       }
       if (!appliedLimitOffset && hasLimitOffset) {
         batches = limitBatches(batches, plan.hints.limit, plan.hints.offset, signal)

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -9,7 +9,7 @@ import { statementScope } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
 import { batchResultsFor, registerBatchResults } from './batchResults.js'
-import { filterBatches, limitBatches, projectExpressionBatches } from './batches.js'
+import { distinctBatches, filterBatches, limitBatches, projectExpressionBatches } from './batches.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
 import { normalizeScanColumnResult } from './scanColumn.js'
 import { executeSort } from './sort.js'
@@ -709,6 +709,26 @@ function executeProject(plan, context) {
  */
 function executeDistinct(plan, context) {
   const child = executePlan({ plan: plan.child, context })
+  const childBatches = batchResultsFor(child)
+  if (childBatches) {
+    const readChildBatches = childBatches.batches
+    /** @returns {AsyncIterable<AsyncBatch>} */
+    function makeBatches() {
+      return distinctBatches(readChildBatches(), context.signal)
+    }
+    const results = {
+      columns: child.columns,
+      maxRows: child.maxRows,
+      async *rows() {
+        yield* batchesToRows(makeBatches(), context.signal)
+      },
+    }
+    return registerBatchResults(results, {
+      schema: childBatches.schema,
+      batches: makeBatches,
+      signal: context.signal,
+    })
+  }
   return {
     columns: child.columns,
     maxRows: child.maxRows,

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -1,6 +1,7 @@
 import { memorySource } from '../backend/dataSource.js'
 import { batchesToRows } from '../backend/batchAdapters.js'
 import { derivedAlias } from '../expression/alias.js'
+import { compileBatchExpression } from '../expression/batch.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { parseSql } from '../parse/parse.js'
 import { planSql, planStatement } from '../plan/plan.js'
@@ -8,7 +9,7 @@ import { statementScope } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
 import { batchResultsFor, registerBatchResults } from './batchResults.js'
-import { limitBatches, projectBatches } from './batches.js'
+import { filterBatches, limitBatches, projectBatches } from './batches.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
 import { normalizeScanColumnResult } from './scanColumn.js'
 import { executeSort } from './sort.js'
@@ -302,18 +303,24 @@ export function executeScan(plan, context, existingColumnResult) {
     const appliedLimitOffset = plan.hints.where
       ? false
       : columnResult.appliedLimitOffset
+    const residualFilter = plan.hints.where && !columnResult.appliedWhere
+      ? compileBatchExpression({ expression: plan.hints.where, schema })
+      : undefined
 
     /** @returns {AsyncIterable<AsyncBatch>} */
     function makeBatches() {
       /** @type {AsyncIterable<AsyncBatch>} */
       let batches = columnBatches(columnResult.chunks(), schema, signal)
+      if (residualFilter) {
+        batches = filterBatches(batches, residualFilter, signal)
+      }
       if (!appliedLimitOffset && hasLimitOffset) {
         batches = limitBatches(batches, plan.hints.limit, plan.hints.offset, signal)
       }
       return batches
     }
 
-    const canUseBatches = !plan.hints.where || columnResult.appliedWhere
+    const canUseBatches = !plan.hints.where || columnResult.appliedWhere || residualFilter !== undefined
     const results = {
       columns: [column],
       numRows: plan.hints.where ? undefined : scanRows,

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -1,4 +1,5 @@
 import { memorySource } from '../backend/dataSource.js'
+import { batchesToRows } from '../backend/batchAdapters.js'
 import { derivedAlias } from '../expression/alias.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { parseSql } from '../parse/parse.js'
@@ -6,6 +7,8 @@ import { planSql, planStatement } from '../plan/plan.js'
 import { statementScope } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
+import { batchResultsFor, registerBatchResults } from './batchResults.js'
+import { limitBatches, projectBatches } from './batches.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
 import { normalizeScanColumnResult } from './scanColumn.js'
 import { executeSort } from './sort.js'
@@ -14,6 +17,7 @@ import { executeWindow } from './window.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
+ * @import { AsyncBatch, ColumnVector, RelationSchema } from '../internalTypes.js'
  * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, ExecuteSqlOptions, ExprNode, IdentifierNode, QueryResults, SelectColumn, SqlPrimitive, Statement } from '../types.js'
  * @import { CountNode, DistinctNode, FilterNode, LimitNode, ProjectNode, QueryPlan, ScanNode, SetOperationNode, TableFunctionNode } from '../plan/types.js'
  */
@@ -294,11 +298,31 @@ export function executeScan(plan, context, existingColumnResult) {
   if (columnResult && scanColumnOptions) {
     const column = plan.hints.columns[0]
     const scanRows = computeScanRows(table.numRows, plan.hints.limit, plan.hints.offset)
-    return {
+    const schema = unknownSchema([column])
+    const appliedLimitOffset = plan.hints.where
+      ? false
+      : columnResult.appliedLimitOffset
+
+    /** @returns {AsyncIterable<AsyncBatch>} */
+    function makeBatches() {
+      /** @type {AsyncIterable<AsyncBatch>} */
+      let batches = columnBatches(columnResult.chunks(), schema, signal)
+      if (!appliedLimitOffset && hasLimitOffset) {
+        batches = limitBatches(batches, plan.hints.limit, plan.hints.offset, signal)
+      }
+      return batches
+    }
+
+    const canUseBatches = !plan.hints.where || columnResult.appliedWhere
+    const results = {
       columns: [column],
       numRows: plan.hints.where ? undefined : scanRows,
       maxRows: scanRows,
       async *rows() {
+        if (canUseBatches) {
+          yield* batchesToRows(makeBatches(), signal)
+          return
+        }
         const columns = [column]
         let result = (async function* () {
           // Creating the chunk stream may itself start I/O, so leave it until
@@ -319,9 +343,6 @@ export function executeScan(plan, context, existingColumnResult) {
           result = filterRows(result, plan.hints.where, context, plan.hints.limit)
         }
         // Filtered LIMIT/OFFSET was intentionally not passed to scanColumn.
-        const appliedLimitOffset = plan.hints.where
-          ? false
-          : columnResult.appliedLimitOffset
         if (!appliedLimitOffset && hasLimitOffset) {
           result = limitRows(result, plan.hints.limit, plan.hints.offset, signal)
         }
@@ -332,6 +353,8 @@ export function executeScan(plan, context, existingColumnResult) {
         signal?.throwIfAborted()
       },
     }
+    if (!canUseBatches) return results
+    return registerBatchResults(results, { schema, batches: makeBatches, signal })
   }
 
   // do the scan
@@ -543,6 +566,31 @@ function executeProject(plan, context) {
     col.type === 'star' || col.type === 'derived' && col.expr.type === 'identifier'
   )
 
+  const childBatches = batchResultsFor(child)
+  const projection = childBatches && resolveable
+    ? simpleProjection(plan.columns, columns, child.columns, childBatches.schema)
+    : undefined
+  if (projection && childBatches) {
+    const readChildBatches = childBatches.batches
+    /** @returns {AsyncIterable<AsyncBatch>} */
+    function makeBatches() {
+      return projectBatches(readChildBatches(), projection.schema, projection.columnIndices)
+    }
+    const results = {
+      columns,
+      numRows: child.numRows,
+      maxRows: child.maxRows,
+      async *rows() {
+        yield* batchesToRows(makeBatches(), context.signal)
+      },
+    }
+    return registerBatchResults(results, {
+      schema: projection.schema,
+      batches: makeBatches,
+      signal: context.signal,
+    })
+  }
+
   return {
     columns,
     numRows: child.numRows,
@@ -689,11 +737,154 @@ function executeDistinct(plan, context) {
  */
 function executeLimit(plan, context) {
   const child = executePlan({ plan: plan.child, context })
+  const childBatches = batchResultsFor(child)
+  if (childBatches) {
+    const readChildBatches = childBatches.batches
+    /** @returns {AsyncIterable<AsyncBatch>} */
+    function makeBatches() {
+      return limitBatches(readChildBatches(), plan.limit, plan.offset, context.signal)
+    }
+    const results = {
+      columns: child.columns,
+      numRows: computeScanRows(child.numRows, plan.limit, plan.offset),
+      maxRows: computeScanRows(child.maxRows, plan.limit, plan.offset),
+      async *rows() {
+        yield* batchesToRows(makeBatches(), context.signal)
+      },
+    }
+    return registerBatchResults(results, {
+      schema: childBatches.schema,
+      batches: makeBatches,
+      signal: context.signal,
+    })
+  }
   return {
     columns: child.columns,
     numRows: computeScanRows(child.numRows, plan.limit, plan.offset),
     maxRows: computeScanRows(child.maxRows, plan.limit, plan.offset),
     rows: () => limitRows(child.rows(), plan.limit, plan.offset, context.signal),
+  }
+}
+
+/**
+ * Wraps one-column source chunks as loaded batches without copying their
+ * arrays. Each source chunk remains the async scheduling unit.
+ *
+ * @param {AsyncIterable<ArrayLike<SqlPrimitive>>} chunks
+ * @param {RelationSchema} schema
+ * @param {AbortSignal} [signal]
+ * @yields {AsyncBatch}
+ */
+async function* columnBatches(chunks, schema, signal) {
+  for await (const chunk of chunks) {
+    signal?.throwIfAborted()
+    const vector = vectorFromChunk(chunk)
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: vector.length },
+      columns: [{ type: 'loaded', vector }],
+    }
+    yield batch
+  }
+  signal?.throwIfAborted()
+}
+
+/**
+ * @param {ArrayLike<SqlPrimitive>} chunk
+ * @returns {ColumnVector}
+ */
+function vectorFromChunk(chunk) {
+  if (Array.isArray(chunk)) {
+    return { type: 'values', values: chunk, length: chunk.length }
+  }
+  if (isNumericArray(chunk)) {
+    return {
+      type: 'typed',
+      values: chunk,
+      length: chunk.length,
+    }
+  }
+  return { type: 'values', values: Array.from(chunk), length: chunk.length }
+}
+
+/**
+ * @param {ArrayLike<SqlPrimitive>} values
+ * @returns {values is import('../internalTypes.js').NumericArray}
+ */
+function isNumericArray(values) {
+  return values instanceof Int8Array
+    || values instanceof Uint8Array
+    || values instanceof Uint8ClampedArray
+    || values instanceof Int16Array
+    || values instanceof Uint16Array
+    || values instanceof Int32Array
+    || values instanceof Uint32Array
+    || values instanceof Float32Array
+    || values instanceof Float64Array
+    || values instanceof BigInt64Array
+    || values instanceof BigUint64Array
+}
+
+/**
+ * @param {string[]} columns
+ * @returns {RelationSchema}
+ */
+function unknownSchema(columns) {
+  return {
+    fields: columns.map(function unknownField(name, id) {
+      return { id, name, dataType: { type: 'unknown' }, nullable: true }
+    }),
+  }
+}
+
+/**
+ * Resolves a simple star/identifier projection to positional batch columns.
+ *
+ * @param {SelectColumn[]} planColumns
+ * @param {string[]} outputColumns
+ * @param {string[]} childColumns
+ * @param {RelationSchema} childSchema
+ * @returns {{ schema: RelationSchema, columnIndices: number[] } | undefined}
+ */
+function simpleProjection(planColumns, outputColumns, childColumns, childSchema) {
+  /** @type {number[]} */
+  const columnIndices = []
+  for (const column of planColumns) {
+    if (column.type === 'star') {
+      const prefix = column.table ? `${column.table}.` : undefined
+      for (let i = 0; i < childColumns.length; i++) {
+        if (!prefix || childColumns[i].startsWith(prefix)) columnIndices.push(i)
+      }
+      continue
+    }
+
+    if (column.expr.type !== 'identifier') return undefined
+    const identifier = column.expr
+    const sourceName = identifier.prefix
+      ? `${identifier.prefix}.${identifier.name}`
+      : identifier.name
+    let index = childColumns.indexOf(sourceName)
+    if (index < 0) {
+      const suffix = `.${identifier.name}`
+      const matches = childColumns
+        .map(function childColumn(name, childIndex) { return { name, childIndex } })
+        .filter(function suffixMatch(candidate) { return candidate.name.endsWith(suffix) })
+      if (matches.length !== 1) return undefined
+      index = matches[0].childIndex
+    }
+    columnIndices.push(index)
+  }
+  if (columnIndices.length !== outputColumns.length) return undefined
+
+  return {
+    schema: {
+      fields: columnIndices.map(function projectedField(childIndex, id) {
+        const field = childSchema.fields[childIndex]
+        return { ...field, id, name: outputColumns[id] }
+      }),
+    },
+    columnIndices,
   }
 }
 

--- a/src/execute/streamingAggregate.js
+++ b/src/execute/streamingAggregate.js
@@ -11,7 +11,7 @@ import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncBatch, BatchAggregateInputs, ColumnVector, CompiledBatchExpression, RelationSchema } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchAggregateInputs, ColumnVector, CompiledBatchExpression } from '../internalTypes.js'
  * @import { AsyncCells, AsyncRow, ExecuteContext, ExprNode, FunctionNode, IdentifierNode, QueryResults, SelectColumn, SqlPrimitive } from '../types.js'
  * @import { HashAggregateNode, ScalarAggregateNode } from '../plan/types.js'
  * @import { Accumulator } from './accumulator.js'
@@ -430,14 +430,14 @@ async function accumulateChunk({ chunk, groupBy, specs, groups, needsRow, contex
  *
  * @param {ExprNode[]} groupBy
  * @param {StreamingAggSpec[]} specs
- * @param {RelationSchema} schema
+ * @param {readonly string[]} columns
  * @returns {BatchAggregateInputs | undefined}
  */
-function compileBatchAggregateInputs(groupBy, specs, schema) {
+function compileBatchAggregateInputs(groupBy, specs, columns) {
   /** @type {CompiledBatchExpression[]} */
   const keys = []
   for (const expression of groupBy) {
-    const key = compileBatchExpression({ expression, schema })
+    const key = compileBatchExpression(expression, columns)
     if (!key) return undefined
     keys.push(key)
   }
@@ -449,11 +449,11 @@ function compileBatchAggregateInputs(groupBy, specs, schema) {
   for (const spec of specs) {
     if (spec.node.filter && !spec.star) return undefined
     const filter = spec.node.filter
-      ? compileBatchExpression({ expression: spec.node.filter, schema })
+      ? compileBatchExpression(spec.node.filter, columns)
       : undefined
     const argument = spec.star
       ? undefined
-      : compileBatchExpression({ expression: spec.node.args[0], schema })
+      : compileBatchExpression(spec.node.args[0], columns)
     if (spec.node.filter && !filter || !spec.star && !argument) return undefined
     filters.push(filter)
     args.push(argument)
@@ -553,7 +553,7 @@ async function accumulateGroups({ child, groupBy, specs, needsRow, context }) {
   const groups = new Map()
   const batchResults = batchResultsFor(child)
   const batchInputs = batchResults && !needsRow
-    ? compileBatchAggregateInputs(groupBy, specs, batchResults.schema)
+    ? compileBatchAggregateInputs(groupBy, specs, batchResults.columns)
     : undefined
   if (batchInputs && batchResults) {
     let rowOffset = 0

--- a/src/execute/streamingAggregate.js
+++ b/src/execute/streamingAggregate.js
@@ -1,13 +1,17 @@
+import { selectedRowCount, valueAt } from '../backend/batch.js'
 import { derivedAlias } from '../expression/alias.js'
+import { compileBatchExpression } from '../expression/batch.js'
 import { evaluateAll, evaluateExpr } from '../expression/evaluate.js'
 import { collectColumnsFromExpr } from '../plan/columns.js'
 import { isAggregateFunc } from '../validation/functions.js'
 import { finalizeAccumulator, newAccumulator, updateAccumulator } from './accumulator.js'
+import { batchResultsFor } from './batchResults.js'
 import { sortEntriesByTerms } from './sort.js'
 import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
+ * @import { AsyncBatch, BatchAggregateInputs, ColumnVector, CompiledBatchExpression, RelationSchema } from '../internalTypes.js'
  * @import { AsyncCells, AsyncRow, ExecuteContext, ExprNode, FunctionNode, IdentifierNode, QueryResults, SelectColumn, SqlPrimitive } from '../types.js'
  * @import { HashAggregateNode, ScalarAggregateNode } from '../plan/types.js'
  * @import { Accumulator } from './accumulator.js'
@@ -420,6 +424,118 @@ async function accumulateChunk({ chunk, groupBy, specs, groups, needsRow, contex
 }
 
 /**
+ * Compiles the expressions an aggregate reads from each input batch. A
+ * filtered non-star aggregate retains the row path because its argument must
+ * only be evaluated for passing rows.
+ *
+ * @param {ExprNode[]} groupBy
+ * @param {StreamingAggSpec[]} specs
+ * @param {RelationSchema} schema
+ * @returns {BatchAggregateInputs | undefined}
+ */
+function compileBatchAggregateInputs(groupBy, specs, schema) {
+  /** @type {CompiledBatchExpression[]} */
+  const keys = []
+  for (const expression of groupBy) {
+    const key = compileBatchExpression({ expression, schema })
+    if (!key) return undefined
+    keys.push(key)
+  }
+
+  /** @type {(CompiledBatchExpression | undefined)[]} */
+  const filters = []
+  /** @type {(CompiledBatchExpression | undefined)[]} */
+  const args = []
+  for (const spec of specs) {
+    if (spec.node.filter && !spec.star) return undefined
+    const filter = spec.node.filter
+      ? compileBatchExpression({ expression: spec.node.filter, schema })
+      : undefined
+    const argument = spec.star
+      ? undefined
+      : compileBatchExpression({ expression: spec.node.args[0], schema })
+    if (spec.node.filter && !filter || !spec.star && !argument) return undefined
+    filters.push(filter)
+    args.push(argument)
+  }
+  return {
+    keys,
+    filters,
+    args,
+  }
+}
+
+/**
+ * Resolves one set of compiled expressions against a batch.
+ *
+ * @param {(CompiledBatchExpression | undefined)[]} expressions
+ * @param {AsyncBatch} batch
+ * @param {ExecuteContext} context
+ * @param {number} rowOffset
+ * @returns {Promise<(ColumnVector | undefined)[]>}
+ */
+function evaluateBatchInputs(expressions, batch, context, rowOffset) {
+  return Promise.all(expressions.map(function evaluateInput(expression) {
+    return expression?.evaluate({ batch, selection: batch.selection, signal: context.signal, rowOffset })
+  }))
+}
+
+/**
+ * Folds a native batch directly into aggregate state without constructing
+ * rows, cells, or per-value promises.
+ *
+ * @param {object} options
+ * @param {AsyncBatch} options.batch
+ * @param {BatchAggregateInputs} options.inputs
+ * @param {StreamingAggSpec[]} options.specs
+ * @param {Map<unknown, StreamingGroup>} options.groups
+ * @param {ExecuteContext} options.context
+ * @param {number} options.rowOffset
+ * @returns {Promise<void>}
+ */
+async function accumulateBatch({ batch, inputs, specs, groups, context, rowOffset }) {
+  const [keys, filters, args] = await Promise.all([
+    evaluateBatchInputs(inputs.keys, batch, context, rowOffset),
+    evaluateBatchInputs(inputs.filters, batch, context, rowOffset),
+    evaluateBatchInputs(inputs.args, batch, context, rowOffset),
+  ])
+  const rowCount = selectedRowCount(batch.selection)
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    if (rowIndex > 0 && rowIndex % CHUNK_SIZE === 0) {
+      await yieldToEventLoop()
+      context.signal?.throwIfAborted()
+    }
+    const keyValues = keys.map(function keyValue(vector) {
+      if (!vector) throw new Error('Missing compiled group key')
+      return valueAt(vector, rowIndex)
+    })
+    const key = keyValues.length === 0
+      ? true
+      : keyValues.length === 1 ? keyify(keyValues[0]) : keyify(...keyValues)
+    let group = groups.get(key)
+    if (!group) {
+      group = {
+        firstRow: undefined,
+        keyValues,
+        accumulators: specs.map(spec => newAccumulator(spec.funcName, spec.node.distinct)),
+      }
+      groups.set(key, group)
+    }
+    for (let specIndex = 0; specIndex < specs.length; specIndex++) {
+      const filter = filters[specIndex]
+      if (filter && !valueAt(filter, rowIndex)) continue
+      const spec = specs[specIndex]
+      if (spec.star && spec.funcName === 'COUNT') {
+        group.accumulators[specIndex].count++
+      } else {
+        const argument = args[specIndex]
+        updateAccumulator(spec.funcName, group.accumulators[specIndex], argument ? valueAt(argument, rowIndex) : null)
+      }
+    }
+  }
+}
+
+/**
  * Consumes the child rows into per-group accumulators, holding at most one
  * chunk of rows at a time. Throws when aborted so partial accumulators are
  * never finalized into results.
@@ -435,6 +551,19 @@ async function accumulateChunk({ chunk, groupBy, specs, groups, needsRow, contex
 async function accumulateGroups({ child, groupBy, specs, needsRow, context }) {
   /** @type {Map<unknown, StreamingGroup>} */
   const groups = new Map()
+  const batchResults = batchResultsFor(child)
+  const batchInputs = batchResults && !needsRow
+    ? compileBatchAggregateInputs(groupBy, specs, batchResults.schema)
+    : undefined
+  if (batchInputs && batchResults) {
+    let rowOffset = 0
+    for await (const batch of batchResults.batches()) {
+      await accumulateBatch({ batch, inputs: batchInputs, specs, groups, context, rowOffset })
+      rowOffset += selectedRowCount(batch.selection)
+      context.signal?.throwIfAborted()
+    }
+    return groups
+  }
   /** @type {AsyncRow[]} */
   let chunk = []
   for await (const row of child.rows()) {

--- a/src/execute/utils.js
+++ b/src/execute/utils.js
@@ -1,3 +1,6 @@
+import { collectBatches } from '../backend/batchAdapters.js'
+import { batchResultsFor } from './batchResults.js'
+
 /**
  * @import { AsyncRow, OrderByItem, QueryResults, SqlPrimitive } from '../types.js'
  */
@@ -49,6 +52,9 @@ export function compareForTerm(a, b, term) {
  * @returns {Promise<Record<string, SqlPrimitive>[]>} array of all yielded values
  */
 export async function collect(results) {
+  const batchResults = batchResultsFor(results)
+  if (batchResults) return await collectBatches(batchResults.batches(), batchResults.signal)
+
   // Collect all rows first, then materialize cells concurrently
   // This enables dataloader-style batching of cell accessors
   /** @type {AsyncRow[]} */

--- a/src/expression/batch.js
+++ b/src/expression/batch.js
@@ -1,12 +1,16 @@
 import { readBatchColumn, selectedRowCount, valueAt } from '../backend/batch.js'
+import { yieldToEventLoop } from '../execute/yield.js'
 import { isStringFunc } from '../validation/functions.js'
 import { applyBinaryOp } from './binary.js'
+import { applyCast, evaluateJsonExtract } from './scalar.js'
 import { evaluateStringFunc } from './strings.js'
 
 /**
  * @import { ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompileState, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
  * @import { ExprNode, FunctionNode, SqlPrimitive } from '../types.js'
  */
+
+const YIELD_INTERVAL = 4000
 
 /**
  * Compiles a supported scalar expression into one column-level evaluation.
@@ -32,7 +36,7 @@ export function compileBatchExpression({ expression, schema }) {
 
   return {
     dependencies,
-    evaluate({ batch, selection, signal }) {
+    evaluate({ batch, selection, signal, rowOffset = 0 }) {
       signal?.throwIfAborted()
       const results = dependencies.map(function readDependency(columnIndex) {
         return readBatchColumn({ batch, columnIndex, selection, signal })
@@ -41,10 +45,10 @@ export function compileBatchExpression({ expression, schema }) {
       if (vectors instanceof Promise) {
         return vectors.then(function evaluateResolved(resolved) {
           signal?.throwIfAborted()
-          return evaluateKernel(kernel, resolved, selection, signal)
+          return evaluateKernel(kernel, resolved, selection, signal, rowOffset)
         })
       }
-      return evaluateKernel(kernel, vectors, selection, signal)
+      return evaluateKernel(kernel, vectors, selection, signal, rowOffset)
     },
   }
 }
@@ -76,8 +80,8 @@ function compileValueKernel(node, state) {
   if (node.type === 'unary') {
     const argument = compileValueKernel(node.argument, state)
     if (!argument) return undefined
-    return function unaryValue(vectors, rowIndex) {
-      const value = argument(vectors, rowIndex)
+    return function unaryValue(vectors, rowIndex, rowOffset) {
+      const value = argument(vectors, rowIndex, rowOffset)
       if (node.op === '-') return value == null ? null : -value
       if (node.op === 'NOT') return value == null ? null : !value
       if (node.op === 'IS NULL') return value == null
@@ -87,15 +91,24 @@ function compileValueKernel(node, state) {
 
   if (node.type === 'binary') {
     if (node.left.type === 'interval' || node.right.type === 'interval') return undefined
+    if ((node.op === 'AND' || node.op === 'OR') && readsIdentifier(node.right)) return undefined
     const left = compileValueKernel(node.left, state)
     const right = compileValueKernel(node.right, state)
     if (!left || !right) return undefined
-    return function binaryValue(vectors, rowIndex) {
-      const leftValue = left(vectors, rowIndex)
+    return function binaryValue(vectors, rowIndex, rowOffset) {
+      const leftValue = left(vectors, rowIndex, rowOffset)
       if (node.op === 'AND' && leftValue != null && !leftValue) return false
       if (node.op === 'OR' && leftValue != null && Boolean(leftValue)) return true
-      const rightValue = right(vectors, rowIndex)
+      const rightValue = right(vectors, rowIndex, rowOffset)
       return applyBinaryOp(node.op, leftValue, rightValue)
+    }
+  }
+
+  if (node.type === 'cast') {
+    const argument = compileValueKernel(node.expr, state)
+    if (!argument) return undefined
+    return function castValue(vectors, rowIndex, rowOffset) {
+      return applyCast(node, argument(vectors, rowIndex, rowOffset), rowOffset + rowIndex + 1)
     }
   }
 
@@ -113,7 +126,8 @@ function compileValueKernel(node, state) {
  */
 function compileFunctionKernel(node, state) {
   const funcName = node.funcName.toUpperCase()
-  if (!isStringFunc(funcName) || node.distinct || node.filter) return undefined
+  if (node.distinct || node.filter) return undefined
+  if (funcName === 'COALESCE' && node.args.slice(1).some(readsIdentifier)) return undefined
   /** @type {ValueKernel[]} */
   const arguments_ = []
   for (const argumentNode of node.args) {
@@ -121,11 +135,29 @@ function compileFunctionKernel(node, state) {
     if (!argument) return undefined
     arguments_.push(argument)
   }
-  return function stringFunctionValue(vectors, rowIndex) {
+  if (funcName === 'COALESCE') {
+    return function coalesceValue(vectors, rowIndex, rowOffset) {
+      for (const argument of arguments_) {
+        const value = argument(vectors, rowIndex, rowOffset)
+        if (value != null) return value
+      }
+      return null
+    }
+  }
+  if (funcName === 'JSON_VALUE' || funcName === 'JSON_QUERY' || funcName === 'JSON_EXTRACT' || funcName === 'JSON_EXTRACT_STRING') {
+    return function jsonValue(vectors, rowIndex, rowOffset) {
+      const args = arguments_.map(function argumentValue(argument) {
+        return argument(vectors, rowIndex, rowOffset)
+      })
+      return evaluateJsonExtract({ funcName, node, args, rowIndex: rowOffset + rowIndex + 1 })
+    }
+  }
+  if (!isStringFunc(funcName)) return undefined
+  return function stringFunctionValue(vectors, rowIndex, rowOffset) {
     const args = arguments_.map(function argumentValue(argument) {
-      return argument(vectors, rowIndex)
+      return argument(vectors, rowIndex, rowOffset)
     })
-    return evaluateStringFunc({ funcName, node, args, rowIndex: rowIndex + 1 })
+    return evaluateStringFunc({ funcName, node, args, rowIndex: rowOffset + rowIndex + 1 })
   }
 }
 
@@ -143,6 +175,15 @@ function resolveIdentifier(identifier, schema) {
   })
   if (exact >= 0) return exact
 
+  if (identifier.prefix) {
+    const bareMatches = []
+    for (let index = 0; index < schema.fields.length; index++) {
+      if (schema.fields[index].name === identifier.name) bareMatches.push(index)
+    }
+    if (bareMatches.length === 1) return bareMatches[0]
+    if (bareMatches.length > 1) return undefined
+  }
+
   const suffix = `.${identifier.name}`
   const matches = []
   for (let i = 0; i < schema.fields.length; i++) {
@@ -156,17 +197,61 @@ function resolveIdentifier(identifier, schema) {
  * @param {ColumnVector[]} vectors
  * @param {RowSelection} selection
  * @param {AbortSignal} [signal]
- * @returns {ColumnVector}
+ * @param {number} [rowOffset]
+ * @returns {ColumnResult}
  */
-function evaluateKernel(kernel, vectors, selection, signal) {
+function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0) {
   const length = selectedRowCount(selection)
+  if (signal && length > YIELD_INTERVAL) {
+    return evaluateKernelAsync(kernel, vectors, length, signal, rowOffset)
+  }
   /** @type {SqlPrimitive[]} */
   const values = new Array(length)
   for (let rowIndex = 0; rowIndex < length; rowIndex++) {
-    if (rowIndex % 4000 === 0) signal?.throwIfAborted()
-    values[rowIndex] = kernel(vectors, rowIndex)
+    if (rowIndex % YIELD_INTERVAL === 0) signal?.throwIfAborted()
+    values[rowIndex] = kernel(vectors, rowIndex, rowOffset)
   }
   return { type: 'values', values, length }
+}
+
+/**
+ * Evaluates a large kernel in macrotask-sized chunks so timer-based aborts
+ * can fire while a native batch is being processed.
+ *
+ * @param {ValueKernel} kernel
+ * @param {ColumnVector[]} vectors
+ * @param {number} length
+ * @param {AbortSignal} signal
+ * @param {number} rowOffset
+ * @returns {Promise<ColumnVector>}
+ */
+async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset) {
+  /** @type {SqlPrimitive[]} */
+  const values = new Array(length)
+  for (let start = 0; start < length; start += YIELD_INTERVAL) {
+    if (start > 0) await yieldToEventLoop()
+    signal.throwIfAborted()
+    const end = Math.min(start + YIELD_INTERVAL, length)
+    for (let rowIndex = start; rowIndex < end; rowIndex++) {
+      values[rowIndex] = kernel(vectors, rowIndex, rowOffset)
+    }
+  }
+  return { type: 'values', values, length }
+}
+
+/**
+ * Returns whether a supported expression subtree can trigger a column read.
+ *
+ * @param {ExprNode} node
+ * @returns {boolean}
+ */
+function readsIdentifier(node) {
+  if (node.type === 'identifier') return true
+  if (node.type === 'unary') return readsIdentifier(node.argument)
+  if (node.type === 'binary') return readsIdentifier(node.left) || readsIdentifier(node.right)
+  if (node.type === 'cast') return readsIdentifier(node.expr)
+  if (node.type === 'function') return node.args.some(readsIdentifier)
+  return false
 }
 
 /**

--- a/src/expression/batch.js
+++ b/src/expression/batch.js
@@ -8,7 +8,7 @@ import { applyCast, evaluateJsonExtract } from './scalar.js'
 import { evaluateStringFunc } from './strings.js'
 
 /**
- * @import { AsyncBatch, ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompiledEvaluator, CompileState, EvaluationContext, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
+ * @import { AsyncBatch, ColumnResult, ColumnVector, CompiledBatchExpression, CompileState, EvaluationContext, RowSelection, ValueKernel } from '../internalTypes.js'
  * @import { ExprNode, FunctionNode, SqlPrimitive } from '../types.js'
  */
 
@@ -22,19 +22,12 @@ const YIELD_INTERVAL = 4000
  * Unsupported expressions return `undefined` so an operator can retain its
  * existing row evaluator without changing semantics.
  *
- * @param {CompileBatchExpressionOptions} options
+ * @param {ExprNode} expression
+ * @param {readonly string[]} columns
  * @returns {CompiledBatchExpression | undefined}
  */
-export function compileBatchExpression({ expression, schema }) {
-  const compiled = compileEvaluator(expression, schema)
-  if (!compiled) return undefined
-
-  return {
-    dependencies: compiled.dependencies,
-    evaluate({ batch, selection, signal, rowOffset = 0, rowOrdinals }) {
-      return compiled.evaluate({ batch, selection, signal, rowOffset, rowOrdinals })
-    },
-  }
+export function compileBatchExpression(expression, columns) {
+  return compileEvaluator(expression, columns)
 }
 
 /**
@@ -43,18 +36,17 @@ export function compileBatchExpression({ expression, schema }) {
  * that only read columns for rows whose branch is reached.
  *
  * @param {ExprNode} node
- * @param {RelationSchema} schema
- * @returns {CompiledEvaluator | undefined}
+ * @param {readonly string[]} columns
+ * @returns {CompiledBatchExpression | undefined}
  */
-function compileEvaluator(node, schema) {
-  const kernel = compileKernelEvaluator(node, schema)
+function compileEvaluator(node, columns) {
+  const kernel = compileKernelEvaluator(node, columns)
   if (kernel) return kernel
 
   if (node.type === 'unary') {
-    const argument = compileEvaluator(node.argument, schema)
+    const argument = compileEvaluator(node.argument, columns)
     if (!argument) return undefined
     return {
-      dependencies: argument.dependencies,
       async evaluate(context) {
         const vector = await argument.evaluate(context)
         return evaluateValues(context, function unaryValue(rowIndex) {
@@ -70,21 +62,18 @@ function compileEvaluator(node, schema) {
 
   if (node.type === 'binary') {
     if (node.left.type === 'interval' || node.right.type === 'interval') return undefined
-    const left = compileEvaluator(node.left, schema)
-    const right = compileEvaluator(node.right, schema)
+    const left = compileEvaluator(node.left, columns)
+    const right = compileEvaluator(node.right, columns)
     if (!left || !right) return undefined
-    const dependencies = mergeDependencies(left.dependencies, right.dependencies)
     if (node.op === 'AND' || node.op === 'OR') {
       const operator = node.op
       return {
-        dependencies,
         evaluate(context) {
           return evaluateLogical(operator, left, right, context)
         },
       }
     }
     return {
-      dependencies,
       async evaluate(context) {
         const [leftVector, rightVector] = await Promise.all([
           left.evaluate(context),
@@ -98,10 +87,9 @@ function compileEvaluator(node, schema) {
   }
 
   if (node.type === 'cast') {
-    const argument = compileEvaluator(node.expr, schema)
+    const argument = compileEvaluator(node.expr, columns)
     if (!argument) return undefined
     return {
-      dependencies: argument.dependencies,
       async evaluate(context) {
         const vector = await argument.evaluate(context)
         return evaluateValues(context, function castValue(rowIndex, streamRowIndex) {
@@ -111,20 +99,20 @@ function compileEvaluator(node, schema) {
     }
   }
 
-  if (node.type === 'function') return compileFunctionEvaluator(node, schema)
-  if (node.type === 'case') return compileCaseEvaluator(node, schema)
+  if (node.type === 'function') return compileFunctionEvaluator(node, columns)
+  if (node.type === 'case') return compileCaseEvaluator(node, columns)
   return undefined
 }
 
 /**
  * @param {ExprNode} node
- * @param {RelationSchema} schema
- * @returns {CompiledEvaluator | undefined}
+ * @param {readonly string[]} columns
+ * @returns {CompiledBatchExpression | undefined}
  */
-function compileKernelEvaluator(node, schema) {
+function compileKernelEvaluator(node, columns) {
   /** @type {CompileState} */
   const state = {
-    schema,
+    columns,
     dependencies: [],
     dependencyPositions: new Map(),
   }
@@ -132,9 +120,8 @@ function compileKernelEvaluator(node, schema) {
   if (!kernel) return undefined
   const { dependencies } = state
   return {
-    dependencies,
     evaluate(context) {
-      const { batch, selection, signal, rowOffset, rowOrdinals } = context
+      const { batch, selection, signal, rowOffset = 0, rowOrdinals } = context
       signal?.throwIfAborted()
       const results = dependencies.map(function readDependency(columnIndex) {
         return readBatchColumn({ batch, columnIndex, selection, signal })
@@ -162,7 +149,7 @@ function compileValueKernel(node, state) {
   }
 
   if (node.type === 'identifier') {
-    const accesses = resolveIdentifier(node, state.schema)
+    const accesses = resolveIdentifier(node, state.columns)
     if (!accesses) return undefined
     const dependencyPositions = accesses.map(function registerAccess(access) {
       let dependencyPosition = state.dependencyPositions.get(access.columnIndex)
@@ -184,7 +171,7 @@ function compileValueKernel(node, state) {
       }
       throw new ColumnNotFoundError({
         missingColumn: `${node.prefix}.${node.name}`,
-        availableColumns: state.schema.fields.map(function fieldName(field) { return field.name }),
+        availableColumns: [...state.columns],
         rowIndex: streamRowIndex + 1,
         ...node,
       })
@@ -284,25 +271,21 @@ function compileFunctionKernel(node, state) {
 
 /**
  * @param {FunctionNode} node
- * @param {RelationSchema} schema
- * @returns {CompiledEvaluator | undefined}
+ * @param {readonly string[]} columns
+ * @returns {CompiledBatchExpression | undefined}
  */
-function compileFunctionEvaluator(node, schema) {
+function compileFunctionEvaluator(node, columns) {
   const funcName = node.funcName.toUpperCase()
   if (node.distinct || node.filter) return undefined
-  /** @type {CompiledEvaluator[]} */
+  /** @type {CompiledBatchExpression[]} */
   const arguments_ = []
   for (const argumentNode of node.args) {
-    const argument = compileEvaluator(argumentNode, schema)
+    const argument = compileEvaluator(argumentNode, columns)
     if (!argument) return undefined
     arguments_.push(argument)
   }
-  const dependencies = mergeDependencies(...arguments_.map(function argumentDependencies(argument) {
-    return argument.dependencies
-  }))
   if (funcName === 'COALESCE') {
     return {
-      dependencies,
       evaluate(context) {
         return evaluateCoalesce(arguments_, context)
       },
@@ -311,7 +294,6 @@ function compileFunctionEvaluator(node, schema) {
   if (funcName !== 'NULLIF' && funcName !== 'JSON_VALUE' && funcName !== 'JSON_QUERY' &&
     funcName !== 'JSON_EXTRACT' && funcName !== 'JSON_EXTRACT_STRING' && !isStringFunc(funcName)) return undefined
   return {
-    dependencies,
     async evaluate(context) {
       const vectors = await Promise.all(arguments_.map(function evaluateArgument(argument) {
         return argument.evaluate(context)
@@ -330,31 +312,23 @@ function compileFunctionEvaluator(node, schema) {
 
 /**
  * @param {import('../types.js').CaseNode} node
- * @param {RelationSchema} schema
- * @returns {CompiledEvaluator | undefined}
+ * @param {readonly string[]} columns
+ * @returns {CompiledBatchExpression | undefined}
  */
-function compileCaseEvaluator(node, schema) {
-  const caseExpression = node.caseExpr ? compileEvaluator(node.caseExpr, schema) : undefined
+function compileCaseEvaluator(node, columns) {
+  const caseExpression = node.caseExpr ? compileEvaluator(node.caseExpr, columns) : undefined
   if (node.caseExpr && !caseExpression) return undefined
-  /** @type {{ condition: CompiledEvaluator, result: CompiledEvaluator }[]} */
+  /** @type {{ condition: CompiledBatchExpression, result: CompiledBatchExpression }[]} */
   const clauses = []
   for (const clause of node.whenClauses) {
-    const condition = compileEvaluator(clause.condition, schema)
-    const result = compileEvaluator(clause.result, schema)
+    const condition = compileEvaluator(clause.condition, columns)
+    const result = compileEvaluator(clause.result, columns)
     if (!condition || !result) return undefined
     clauses.push({ condition, result })
   }
-  const elseResult = node.elseResult ? compileEvaluator(node.elseResult, schema) : undefined
+  const elseResult = node.elseResult ? compileEvaluator(node.elseResult, columns) : undefined
   if (node.elseResult && !elseResult) return undefined
-  const dependencies = mergeDependencies(
-    caseExpression?.dependencies ?? [],
-    ...clauses.flatMap(function clauseDependencies(clause) {
-      return [clause.condition.dependencies, clause.result.dependencies]
-    }),
-    elseResult?.dependencies ?? []
-  )
   return {
-    dependencies,
     evaluate(context) {
       return evaluateCase(caseExpression, clauses, elseResult, context)
     },
@@ -367,8 +341,8 @@ function compileCaseEvaluator(node, schema) {
  * and computed columns, preserving row evaluator short-circuit behavior.
  *
  * @param {'AND' | 'OR'} operator
- * @param {CompiledEvaluator} left
- * @param {CompiledEvaluator} right
+ * @param {CompiledBatchExpression} left
+ * @param {CompiledBatchExpression} right
  * @param {EvaluationContext} context
  * @returns {Promise<ColumnVector>}
  */
@@ -406,9 +380,9 @@ async function evaluateLogical(operator, left, right, context) {
 }
 
 /**
- * @param {CompiledEvaluator | undefined} caseExpression
- * @param {{ condition: CompiledEvaluator, result: CompiledEvaluator }[]} clauses
- * @param {CompiledEvaluator | undefined} elseResult
+ * @param {CompiledBatchExpression | undefined} caseExpression
+ * @param {{ condition: CompiledBatchExpression, result: CompiledBatchExpression }[]} clauses
+ * @param {CompiledBatchExpression | undefined} elseResult
  * @param {EvaluationContext} context
  * @returns {Promise<ColumnVector>}
  */
@@ -462,7 +436,7 @@ async function evaluateCase(caseExpression, clauses, elseResult, context) {
  * Evaluates each argument only for rows that remained null after the previous
  * argument, matching COALESCE's lazy row semantics.
  *
- * @param {CompiledEvaluator[]} arguments_
+ * @param {CompiledBatchExpression[]} arguments_
  * @param {EvaluationContext} context
  * @returns {Promise<ColumnVector>}
  */
@@ -518,23 +492,6 @@ function allIndices(length) {
 }
 
 /**
- * @param {...(readonly number[])} dependencies
- * @returns {number[]}
- */
-function mergeDependencies(...dependencies) {
-  const merged = []
-  const seen = new Set()
-  for (const group of dependencies) {
-    for (const dependency of group) {
-      if (seen.has(dependency)) continue
-      seen.add(dependency)
-      merged.push(dependency)
-    }
-  }
-  return merged
-}
-
-/**
  * @param {EvaluationContext} context
  * @param {(rowIndex: number, streamRowIndex: number) => SqlPrimitive} evaluate
  * @returns {Promise<ColumnVector>}
@@ -571,21 +528,19 @@ async function visitRows(length, signal, visit) {
  */
 function streamRowIndex(context, rowIndex) {
   const ordinal = context.rowOrdinals ? Number(valueAt(context.rowOrdinals, rowIndex)) : rowIndex
-  return context.rowOffset + ordinal
+  return (context.rowOffset ?? 0) + ordinal
 }
 
 /**
  * @param {import('../types.js').IdentifierNode} identifier
- * @param {RelationSchema} schema
+ * @param {readonly string[]} columns
  * @returns {{ columnIndex: number, field?: string }[] | undefined}
  */
-function resolveIdentifier(identifier, schema) {
+function resolveIdentifier(identifier, columns) {
   const sourceName = identifier.prefix
     ? `${identifier.prefix}.${identifier.name}`
     : identifier.name
-  const exact = schema.fields.findIndex(function exactName(field) {
-    return field.name === sourceName
-  })
+  const exact = columns.indexOf(sourceName)
   if (exact >= 0) return [{ columnIndex: exact }]
 
   if (identifier.prefix) {
@@ -593,8 +548,8 @@ function resolveIdentifier(identifier, schema) {
     const prefixedMatches = []
     const baseMatches = []
     const baseSuffix = `.${identifier.prefix}`
-    for (let index = 0; index < schema.fields.length; index++) {
-      const fieldName = schema.fields[index].name
+    for (let index = 0; index < columns.length; index++) {
+      const fieldName = columns[index]
       if (fieldName.startsWith(prefix)) prefixedMatches.push(index)
       if (fieldName === identifier.prefix || fieldName.endsWith(baseSuffix)) baseMatches.push(index)
     }
@@ -607,17 +562,15 @@ function resolveIdentifier(identifier, schema) {
     if (baseMatches.length === 1) {
       accesses.push({ columnIndex: baseMatches[0], field: identifier.name })
     }
-    const bare = schema.fields.findIndex(function bareName(field) {
-      return field.name === identifier.name
-    })
+    const bare = columns.indexOf(identifier.name)
     if (bare >= 0) accesses.push({ columnIndex: bare })
     return accesses.length > 0 ? accesses : undefined
   }
 
   const suffix = `.${identifier.name}`
   const matches = []
-  for (let i = 0; i < schema.fields.length; i++) {
-    if (schema.fields[i].name.endsWith(suffix)) matches.push(i)
+  for (let i = 0; i < columns.length; i++) {
+    if (columns[i].endsWith(suffix)) matches.push(i)
   }
   return matches.length === 1 ? [{ columnIndex: matches[0] }] : undefined
 }

--- a/src/expression/batch.js
+++ b/src/expression/batch.js
@@ -1,4 +1,5 @@
-import { readBatchColumn, selectedRowCount, valueAt } from '../backend/batch.js'
+import { composeSelections, readBatchColumn, selectedRowCount, valueAt } from '../backend/batch.js'
+import { sqlEquals } from '../execute/utils.js'
 import { yieldToEventLoop } from '../execute/yield.js'
 import { isStringFunc } from '../validation/functions.js'
 import { applyBinaryOp } from './binary.js'
@@ -6,10 +7,9 @@ import { applyCast, evaluateJsonExtract } from './scalar.js'
 import { evaluateStringFunc } from './strings.js'
 
 /**
- * @import { ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompileState, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
+ * @import { ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompiledEvaluator, CompileState, EvaluationContext, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
  * @import { ExprNode, FunctionNode, SqlPrimitive } from '../types.js'
  */
-
 const YIELD_INTERVAL = 4000
 
 /**
@@ -24,19 +24,115 @@ const YIELD_INTERVAL = 4000
  * @returns {CompiledBatchExpression | undefined}
  */
 export function compileBatchExpression({ expression, schema }) {
+  const compiled = compileEvaluator(expression, schema)
+  if (!compiled) return undefined
+
+  return {
+    dependencies: compiled.dependencies,
+    evaluate({ batch, selection, signal, rowOffset = 0 }) {
+      return compiled.evaluate({ batch, selection, signal, rowOffset })
+    },
+  }
+}
+
+/**
+ * Compiles an expression as one vector kernel when every dependency may be
+ * read eagerly. Lazy control flow falls back to selection-aware evaluators
+ * that only read columns for rows whose branch is reached.
+ *
+ * @param {ExprNode} node
+ * @param {RelationSchema} schema
+ * @returns {CompiledEvaluator | undefined}
+ */
+function compileEvaluator(node, schema) {
+  const kernel = compileKernelEvaluator(node, schema)
+  if (kernel) return kernel
+
+  if (node.type === 'unary') {
+    const argument = compileEvaluator(node.argument, schema)
+    if (!argument) return undefined
+    return {
+      dependencies: argument.dependencies,
+      async evaluate(context) {
+        const vector = await argument.evaluate(context)
+        return evaluateValues(context, function unaryValue(rowIndex) {
+          const value = valueAt(vector, rowIndex)
+          if (node.op === '-') return value == null ? null : -value
+          if (node.op === 'NOT') return value == null ? null : !value
+          if (node.op === 'IS NULL') return value == null
+          return value != null
+        })
+      },
+    }
+  }
+
+  if (node.type === 'binary') {
+    if (node.left.type === 'interval' || node.right.type === 'interval') return undefined
+    const left = compileEvaluator(node.left, schema)
+    const right = compileEvaluator(node.right, schema)
+    if (!left || !right) return undefined
+    const dependencies = mergeDependencies(left.dependencies, right.dependencies)
+    if (node.op === 'AND' || node.op === 'OR') {
+      const operator = node.op
+      return {
+        dependencies,
+        evaluate(context) {
+          return evaluateLogical(operator, left, right, context)
+        },
+      }
+    }
+    return {
+      dependencies,
+      async evaluate(context) {
+        const [leftVector, rightVector] = await Promise.all([
+          left.evaluate(context),
+          right.evaluate(context),
+        ])
+        return evaluateValues(context, function binaryValue(rowIndex) {
+          return applyBinaryOp(node.op, valueAt(leftVector, rowIndex), valueAt(rightVector, rowIndex))
+        })
+      },
+    }
+  }
+
+  if (node.type === 'cast') {
+    const argument = compileEvaluator(node.expr, schema)
+    if (!argument) return undefined
+    return {
+      dependencies: argument.dependencies,
+      async evaluate(context) {
+        const vector = await argument.evaluate(context)
+        return evaluateValues(context, function castValue(rowIndex, streamRowIndex) {
+          return applyCast(node, valueAt(vector, rowIndex), streamRowIndex + 1)
+        })
+      },
+    }
+  }
+
+  if (node.type === 'function') return compileFunctionEvaluator(node, schema)
+  if (node.type === 'case') return compileCaseEvaluator(node, schema)
+  return undefined
+}
+
+/**
+ * @param {ExprNode} node
+ * @param {RelationSchema} schema
+ * @returns {CompiledEvaluator | undefined}
+ */
+function compileKernelEvaluator(node, schema) {
   /** @type {CompileState} */
   const state = {
     schema,
     dependencies: [],
     dependencyPositions: new Map(),
   }
-  const kernel = compileValueKernel(expression, state)
+  const kernel = compileValueKernel(node, state)
   if (!kernel) return undefined
   const { dependencies } = state
-
   return {
     dependencies,
-    evaluate({ batch, selection, signal, rowOffset = 0 }) {
+    evaluate(context) {
+      const { batch, selection, signal, rowOffset, positions } = context
       signal?.throwIfAborted()
       const results = dependencies.map(function readDependency(columnIndex) {
         return readBatchColumn({ batch, columnIndex, selection, signal })
@@ -45,10 +141,10 @@ export function compileBatchExpression({ expression, schema }) {
       if (vectors instanceof Promise) {
         return vectors.then(function evaluateResolved(resolved) {
           signal?.throwIfAborted()
-          return evaluateKernel(kernel, resolved, selection, signal, rowOffset)
+          return evaluateKernel(kernel, resolved, selection, signal, rowOffset, positions)
         })
       }
-      return evaluateKernel(kernel, vectors, selection, signal, rowOffset)
+      return evaluateKernel(kernel, vectors, selection, signal, rowOffset, positions)
     },
   }
 }
@@ -80,8 +176,8 @@ function compileValueKernel(node, state) {
   if (node.type === 'unary') {
     const argument = compileValueKernel(node.argument, state)
     if (!argument) return undefined
-    return function unaryValue(vectors, rowIndex, rowOffset) {
-      const value = argument(vectors, rowIndex, rowOffset)
+    return function unaryValue(vectors, rowIndex, streamRowIndex) {
+      const value = argument(vectors, rowIndex, streamRowIndex)
       if (node.op === '-') return value == null ? null : -value
       if (node.op === 'NOT') return value == null ? null : !value
       if (node.op === 'IS NULL') return value == null
@@ -95,11 +191,11 @@ function compileValueKernel(node, state) {
     const left = compileValueKernel(node.left, state)
     const right = compileValueKernel(node.right, state)
     if (!left || !right) return undefined
-    return function binaryValue(vectors, rowIndex, rowOffset) {
-      const leftValue = left(vectors, rowIndex, rowOffset)
+    return function binaryValue(vectors, rowIndex, streamRowIndex) {
+      const leftValue = left(vectors, rowIndex, streamRowIndex)
       if (node.op === 'AND' && leftValue != null && !leftValue) return false
       if (node.op === 'OR' && leftValue != null && Boolean(leftValue)) return true
-      const rightValue = right(vectors, rowIndex, rowOffset)
+      const rightValue = right(vectors, rowIndex, streamRowIndex)
       return applyBinaryOp(node.op, leftValue, rightValue)
     }
   }
@@ -107,8 +203,8 @@ function compileValueKernel(node, state) {
   if (node.type === 'cast') {
     const argument = compileValueKernel(node.expr, state)
     if (!argument) return undefined
-    return function castValue(vectors, rowIndex, rowOffset) {
-      return applyCast(node, argument(vectors, rowIndex, rowOffset), rowOffset + rowIndex + 1)
+    return function castValue(vectors, rowIndex, streamRowIndex) {
+      return applyCast(node, argument(vectors, rowIndex, streamRowIndex), streamRowIndex + 1)
     }
   }
 
@@ -136,29 +232,327 @@ function compileFunctionKernel(node, state) {
     arguments_.push(argument)
   }
   if (funcName === 'COALESCE') {
-    return function coalesceValue(vectors, rowIndex, rowOffset) {
+    return function coalesceValue(vectors, rowIndex, streamRowIndex) {
       for (const argument of arguments_) {
-        const value = argument(vectors, rowIndex, rowOffset)
+        const value = argument(vectors, rowIndex, streamRowIndex)
         if (value != null) return value
       }
       return null
     }
   }
+  if (funcName === 'NULLIF') {
+    return function nullIfValue(vectors, rowIndex, streamRowIndex) {
+      const first = arguments_[0](vectors, rowIndex, streamRowIndex)
+      const second = arguments_[1](vectors, rowIndex, streamRowIndex)
+      return sqlEquals(first, second) ? null : first
+    }
+  }
   if (funcName === 'JSON_VALUE' || funcName === 'JSON_QUERY' || funcName === 'JSON_EXTRACT' || funcName === 'JSON_EXTRACT_STRING') {
-    return function jsonValue(vectors, rowIndex, rowOffset) {
+    return function jsonValue(vectors, rowIndex, streamRowIndex) {
       const args = arguments_.map(function argumentValue(argument) {
-        return argument(vectors, rowIndex, rowOffset)
+        return argument(vectors, rowIndex, streamRowIndex)
       })
-      return evaluateJsonExtract({ funcName, node, args, rowIndex: rowOffset + rowIndex + 1 })
+      return evaluateJsonExtract({ funcName, node, args, rowIndex: streamRowIndex + 1 })
     }
   }
   if (!isStringFunc(funcName)) return undefined
-  return function stringFunctionValue(vectors, rowIndex, rowOffset) {
+  return function stringFunctionValue(vectors, rowIndex, streamRowIndex) {
     const args = arguments_.map(function argumentValue(argument) {
-      return argument(vectors, rowIndex, rowOffset)
+      return argument(vectors, rowIndex, streamRowIndex)
     })
-    return evaluateStringFunc({ funcName, node, args, rowIndex: rowOffset + rowIndex + 1 })
+    return evaluateStringFunc({ funcName, node, args, rowIndex: streamRowIndex + 1 })
   }
+}
+
+/**
+ * @param {FunctionNode} node
+ * @param {RelationSchema} schema
+ * @returns {CompiledEvaluator | undefined}
+ */
+function compileFunctionEvaluator(node, schema) {
+  const funcName = node.funcName.toUpperCase()
+  if (node.distinct || node.filter) return undefined
+  /** @type {CompiledEvaluator[]} */
+  const arguments_ = []
+  for (const argumentNode of node.args) {
+    const argument = compileEvaluator(argumentNode, schema)
+    if (!argument) return undefined
+    arguments_.push(argument)
+  }
+  const dependencies = mergeDependencies(...arguments_.map(function argumentDependencies(argument) {
+    return argument.dependencies
+  }))
+  if (funcName === 'COALESCE') {
+    return {
+      dependencies,
+      evaluate(context) {
+        return evaluateCoalesce(arguments_, context)
+      },
+    }
+  }
+  if (funcName !== 'NULLIF' && funcName !== 'JSON_VALUE' && funcName !== 'JSON_QUERY' &&
+    funcName !== 'JSON_EXTRACT' && funcName !== 'JSON_EXTRACT_STRING' && !isStringFunc(funcName)) return undefined
+  return {
+    dependencies,
+    async evaluate(context) {
+      const vectors = await Promise.all(arguments_.map(function evaluateArgument(argument) {
+        return argument.evaluate(context)
+      }))
+      return evaluateValues(context, function functionValue(rowIndex, streamRowIndex) {
+        const args = vectors.map(function argumentValue(vector) { return valueAt(vector, rowIndex) })
+        if (funcName === 'NULLIF') return sqlEquals(args[0], args[1]) ? null : args[0]
+        if (funcName === 'JSON_VALUE' || funcName === 'JSON_QUERY' || funcName === 'JSON_EXTRACT' || funcName === 'JSON_EXTRACT_STRING') {
+          return evaluateJsonExtract({ funcName, node, args, rowIndex: streamRowIndex + 1 })
+        }
+        return evaluateStringFunc({ funcName, node, args, rowIndex: streamRowIndex + 1 })
+      })
+    },
+  }
+}
+
+/**
+ * @param {import('../types.js').CaseNode} node
+ * @param {RelationSchema} schema
+ * @returns {CompiledEvaluator | undefined}
+ */
+function compileCaseEvaluator(node, schema) {
+  const caseExpression = node.caseExpr ? compileEvaluator(node.caseExpr, schema) : undefined
+  if (node.caseExpr && !caseExpression) return undefined
+  /** @type {{ condition: CompiledEvaluator, result: CompiledEvaluator }[]} */
+  const clauses = []
+  for (const clause of node.whenClauses) {
+    const condition = compileEvaluator(clause.condition, schema)
+    const result = compileEvaluator(clause.result, schema)
+    if (!condition || !result) return undefined
+    clauses.push({ condition, result })
+  }
+  const elseResult = node.elseResult ? compileEvaluator(node.elseResult, schema) : undefined
+  if (node.elseResult && !elseResult) return undefined
+  const dependencies = mergeDependencies(
+    caseExpression?.dependencies ?? [],
+    ...clauses.flatMap(function clauseDependencies(clause) {
+      return [clause.condition.dependencies, clause.result.dependencies]
+    }),
+    elseResult?.dependencies ?? []
+  )
+  return {
+    dependencies,
+    evaluate(context) {
+      return evaluateCase(caseExpression, clauses, elseResult, context)
+    },
+  }
+}
+
+/**
+ * Evaluates the right side only for rows whose left side does not determine
+ * the logical result. The resulting subset is also passed to deferred source
+ * and computed columns, preserving row evaluator short-circuit behavior.
+ *
+ * @param {'AND' | 'OR'} operator
+ * @param {CompiledEvaluator} left
+ * @param {CompiledEvaluator} right
+ * @param {EvaluationContext} context
+ * @returns {Promise<ColumnVector>}
+ */
+async function evaluateLogical(operator, left, right, context) {
+  const leftVector = await left.evaluate(context)
+  const length = selectedRowCount(context.selection)
+  /** @type {SqlPrimitive[]} */
+  const values = new Array(length)
+  const needed = new Uint32Array(length)
+  let neededCount = 0
+  await visitRows(length, context.signal, function classifyLeft(rowIndex) {
+    const value = valueAt(leftVector, rowIndex)
+    const decided = operator === 'AND'
+      ? value != null && !value
+      : value != null && Boolean(value)
+    if (decided) {
+      values[rowIndex] = operator === 'AND' ? false : true
+    } else {
+      needed[neededCount++] = rowIndex
+    }
+  })
+  if (neededCount === 0) return { type: 'values', values, length }
+
+  const neededIndices = needed.subarray(0, neededCount)
+  const rightVector = await right.evaluate(subsetContext(context, neededIndices))
+  await visitRows(neededCount, context.signal, function combineRight(subsetIndex) {
+    const rowIndex = neededIndices[subsetIndex]
+    values[rowIndex] = applyBinaryOp(
+      operator,
+      valueAt(leftVector, rowIndex),
+      valueAt(rightVector, subsetIndex)
+    )
+  })
+  return { type: 'values', values, length }
+}
+
+/**
+ * @param {CompiledEvaluator | undefined} caseExpression
+ * @param {{ condition: CompiledEvaluator, result: CompiledEvaluator }[]} clauses
+ * @param {CompiledEvaluator | undefined} elseResult
+ * @param {EvaluationContext} context
+ * @returns {Promise<ColumnVector>}
+ */
+async function evaluateCase(caseExpression, clauses, elseResult, context) {
+  const length = selectedRowCount(context.selection)
+  /** @type {SqlPrimitive[]} */
+  const values = new Array(length)
+  const caseVector = caseExpression ? await caseExpression.evaluate(context) : undefined
+  let remaining = allIndices(length)
+
+  for (const clause of clauses) {
+    if (remaining.length === 0) break
+    const remainingContext = subsetContext(context, remaining)
+    const conditionVector = await clause.condition.evaluate(remainingContext)
+    const matched = new Uint32Array(remaining.length)
+    const unmatched = new Uint32Array(remaining.length)
+    let matchedCount = 0
+    let unmatchedCount = 0
+    await visitRows(remaining.length, context.signal, function classifyCondition(subsetIndex) {
+      const rowIndex = remaining[subsetIndex]
+      const condition = valueAt(conditionVector, subsetIndex)
+      const matches = caseVector
+        ? sqlEquals(valueAt(caseVector, rowIndex), condition)
+        : Boolean(condition)
+      if (matches) matched[matchedCount++] = rowIndex
+      else unmatched[unmatchedCount++] = rowIndex
+    })
+
+    if (matchedCount > 0) {
+      const matchedIndices = matched.subarray(0, matchedCount)
+      const resultVector = await clause.result.evaluate(subsetContext(context, matchedIndices))
+      await visitRows(matchedCount, context.signal, function scatterResult(subsetIndex) {
+        values[matchedIndices[subsetIndex]] = valueAt(resultVector, subsetIndex)
+      })
+    }
+    remaining = unmatched.subarray(0, unmatchedCount)
+  }
+
+  if (remaining.length > 0 && elseResult) {
+    const resultVector = await elseResult.evaluate(subsetContext(context, remaining))
+    await visitRows(remaining.length, context.signal, function scatterElse(subsetIndex) {
+      values[remaining[subsetIndex]] = valueAt(resultVector, subsetIndex)
+    })
+  } else {
+    for (const rowIndex of remaining) values[rowIndex] = null
+  }
+  return { type: 'values', values, length }
+}
+
+/**
+ * Evaluates each argument only for rows that remained null after the previous
+ * argument, matching COALESCE's lazy row semantics.
+ *
+ * @param {CompiledEvaluator[]} arguments_
+ * @param {EvaluationContext} context
+ * @returns {Promise<ColumnVector>}
+ */
+async function evaluateCoalesce(arguments_, context) {
+  const length = selectedRowCount(context.selection)
+  /** @type {SqlPrimitive[]} */
+  const values = new Array(length)
+  let remaining = allIndices(length)
+  for (const argument of arguments_) {
+    if (remaining.length === 0) break
+    const vector = await argument.evaluate(subsetContext(context, remaining))
+    const nullRows = new Uint32Array(remaining.length)
+    let nullCount = 0
+    await visitRows(remaining.length, context.signal, function chooseValue(subsetIndex) {
+      const rowIndex = remaining[subsetIndex]
+      const value = valueAt(vector, subsetIndex)
+      if (value == null) nullRows[nullCount++] = rowIndex
+      else values[rowIndex] = value
+    })
+    remaining = nullRows.subarray(0, nullCount)
+  }
+  for (const rowIndex of remaining) values[rowIndex] = null
+  return { type: 'values', values, length }
+}
+
+/**
+ * @param {EvaluationContext} context
+ * @param {Uint32Array} indices - positions in the context's selected rows
+ * @returns {EvaluationContext}
+ */
+function subsetContext(context, indices) {
+  const length = selectedRowCount(context.selection)
+  const selection = composeSelections(context.selection, {
+    type: 'indices',
+    indices,
+    length,
+  })
+  const positions = new Uint32Array(indices.length)
+  for (let index = 0; index < indices.length; index++) {
+    positions[index] = context.positions?.[indices[index]] ?? indices[index]
+  }
+  return { ...context, selection, positions }
+}
+
+/**
+ * @param {number} length
+ * @returns {Uint32Array}
+ */
+function allIndices(length) {
+  const indices = new Uint32Array(length)
+  for (let index = 0; index < length; index++) indices[index] = index
+  return indices
+}
+
+/**
+ * @param {...(readonly number[])} dependencies
+ * @returns {number[]}
+ */
+function mergeDependencies(...dependencies) {
+  const merged = []
+  const seen = new Set()
+  for (const group of dependencies) {
+    for (const dependency of group) {
+      if (seen.has(dependency)) continue
+      seen.add(dependency)
+      merged.push(dependency)
+    }
+  }
+  return merged
+}
+
+/**
+ * @param {EvaluationContext} context
+ * @param {(rowIndex: number, streamRowIndex: number) => SqlPrimitive} evaluate
+ * @returns {Promise<ColumnVector>}
+ */
+async function evaluateValues(context, evaluate) {
+  const length = selectedRowCount(context.selection)
+  /** @type {SqlPrimitive[]} */
+  const values = new Array(length)
+  await visitRows(length, context.signal, function evaluateRow(rowIndex) {
+    values[rowIndex] = evaluate(rowIndex, streamRowIndex(context, rowIndex))
+  })
+  return { type: 'values', values, length }
+}
+
+/**
+ * @param {number} length
+ * @param {AbortSignal | undefined} signal
+ * @param {(rowIndex: number) => void} visit
+ * @returns {Promise<void>}
+ */
+async function visitRows(length, signal, visit) {
+  for (let start = 0; start < length; start += YIELD_INTERVAL) {
+    if (signal && start > 0) await yieldToEventLoop()
+    signal?.throwIfAborted()
+    const end = Math.min(start + YIELD_INTERVAL, length)
+    for (let rowIndex = start; rowIndex < end; rowIndex++) visit(rowIndex)
+  }
+}
+
+/**
+ * @param {EvaluationContext} context
+ * @param {number} rowIndex
+ * @returns {number}
+ */
+function streamRowIndex(context, rowIndex) {
+  return context.rowOffset + (context.positions?.[rowIndex] ?? rowIndex)
 }
 
 /**
@@ -198,18 +592,19 @@ function resolveIdentifier(identifier, schema) {
  * @param {RowSelection} selection
  * @param {AbortSignal} [signal]
  * @param {number} [rowOffset]
+ * @param {Uint32Array} [positions]
  * @returns {ColumnResult}
  */
-function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0) {
+function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0, positions) {
   const length = selectedRowCount(selection)
   if (signal && length > YIELD_INTERVAL) {
-    return evaluateKernelAsync(kernel, vectors, length, signal, rowOffset)
+    return evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, positions)
   }
   /** @type {SqlPrimitive[]} */
   const values = new Array(length)
   for (let rowIndex = 0; rowIndex < length; rowIndex++) {
     if (rowIndex % YIELD_INTERVAL === 0) signal?.throwIfAborted()
-    values[rowIndex] = kernel(vectors, rowIndex, rowOffset)
+    values[rowIndex] = kernel(vectors, rowIndex, rowOffset + (positions?.[rowIndex] ?? rowIndex))
   }
   return { type: 'values', values, length }
 }
@@ -223,9 +618,10 @@ function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0) {
  * @param {number} length
  * @param {AbortSignal} signal
  * @param {number} rowOffset
+ * @param {Uint32Array} [positions]
  * @returns {Promise<ColumnVector>}
  */
-async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset) {
+async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, positions) {
   /** @type {SqlPrimitive[]} */
   const values = new Array(length)
   for (let start = 0; start < length; start += YIELD_INTERVAL) {
@@ -233,7 +629,7 @@ async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset) {
     signal.throwIfAborted()
     const end = Math.min(start + YIELD_INTERVAL, length)
     for (let rowIndex = start; rowIndex < end; rowIndex++) {
-      values[rowIndex] = kernel(vectors, rowIndex, rowOffset)
+      values[rowIndex] = kernel(vectors, rowIndex, rowOffset + (positions?.[rowIndex] ?? rowIndex))
     }
   }
   return { type: 'values', values, length }

--- a/src/expression/batch.js
+++ b/src/expression/batch.js
@@ -1,15 +1,17 @@
-import { composeSelections, readBatchColumn, selectedRowCount, valueAt } from '../backend/batch.js'
-import { sqlEquals } from '../execute/utils.js'
+import { composeSelections, readBatchColumn, selectVector, selectedRowCount, valueAt } from '../backend/batch.js'
+import { isPlainObject, sqlEquals } from '../execute/utils.js'
 import { yieldToEventLoop } from '../execute/yield.js'
 import { isStringFunc } from '../validation/functions.js'
+import { ColumnNotFoundError } from '../validation/tables.js'
 import { applyBinaryOp } from './binary.js'
 import { applyCast, evaluateJsonExtract } from './scalar.js'
 import { evaluateStringFunc } from './strings.js'
 
 /**
- * @import { ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompiledEvaluator, CompileState, EvaluationContext, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
+ * @import { AsyncBatch, ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompiledEvaluator, CompileState, EvaluationContext, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
  * @import { ExprNode, FunctionNode, SqlPrimitive } from '../types.js'
  */
+
 const YIELD_INTERVAL = 4000
 
 /**
@@ -29,8 +31,8 @@ export function compileBatchExpression({ expression, schema }) {
 
   return {
     dependencies: compiled.dependencies,
-    evaluate({ batch, selection, signal, rowOffset = 0 }) {
-      return compiled.evaluate({ batch, selection, signal, rowOffset })
+    evaluate({ batch, selection, signal, rowOffset = 0, rowOrdinals }) {
+      return compiled.evaluate({ batch, selection, signal, rowOffset, rowOrdinals })
     },
   }
 }
@@ -132,7 +134,7 @@ function compileKernelEvaluator(node, schema) {
   return {
     dependencies,
     evaluate(context) {
-      const { batch, selection, signal, rowOffset, positions } = context
+      const { batch, selection, signal, rowOffset, rowOrdinals } = context
       signal?.throwIfAborted()
       const results = dependencies.map(function readDependency(columnIndex) {
         return readBatchColumn({ batch, columnIndex, selection, signal })
@@ -141,10 +143,10 @@ function compileKernelEvaluator(node, schema) {
       if (vectors instanceof Promise) {
         return vectors.then(function evaluateResolved(resolved) {
           signal?.throwIfAborted()
-          return evaluateKernel(kernel, resolved, selection, signal, rowOffset, positions)
+          return evaluateKernel(kernel, resolved, selection, signal, rowOffset, rowOrdinals)
         })
       }
-      return evaluateKernel(kernel, vectors, selection, signal, rowOffset, positions)
+      return evaluateKernel(kernel, vectors, selection, signal, rowOffset, rowOrdinals)
     },
   }
 }
@@ -160,16 +162,32 @@ function compileValueKernel(node, state) {
   }
 
   if (node.type === 'identifier') {
-    const columnIndex = resolveIdentifier(node, state.schema)
-    if (columnIndex === undefined) return undefined
-    let dependencyPosition = state.dependencyPositions.get(columnIndex)
-    if (dependencyPosition === undefined) {
-      dependencyPosition = state.dependencies.length
-      state.dependencies.push(columnIndex)
-      state.dependencyPositions.set(columnIndex, dependencyPosition)
-    }
-    return function identifierValue(vectors, rowIndex) {
-      return valueAt(vectors[dependencyPosition], rowIndex)
+    const accesses = resolveIdentifier(node, state.schema)
+    if (!accesses) return undefined
+    const dependencyPositions = accesses.map(function registerAccess(access) {
+      let dependencyPosition = state.dependencyPositions.get(access.columnIndex)
+      if (dependencyPosition === undefined) {
+        dependencyPosition = state.dependencies.length
+        state.dependencies.push(access.columnIndex)
+        state.dependencyPositions.set(access.columnIndex, dependencyPosition)
+      }
+      return dependencyPosition
+    })
+    return function identifierValue(vectors, rowIndex, streamRowIndex) {
+      for (let index = 0; index < accesses.length; index++) {
+        const access = accesses[index]
+        const value = valueAt(vectors[dependencyPositions[index]], rowIndex)
+        if (!access.field) return value
+        if (isPlainObject(value) && Object.prototype.hasOwnProperty.call(value, access.field)) {
+          return value[access.field]
+        }
+      }
+      throw new ColumnNotFoundError({
+        missingColumn: `${node.prefix}.${node.name}`,
+        availableColumns: state.schema.fields.map(function fieldName(field) { return field.name }),
+        rowIndex: streamRowIndex + 1,
+        ...node,
+      })
     }
   }
 
@@ -482,11 +500,11 @@ function subsetContext(context, indices) {
     indices,
     length,
   })
-  const positions = new Uint32Array(indices.length)
-  for (let index = 0; index < indices.length; index++) {
-    positions[index] = context.positions?.[indices[index]] ?? indices[index]
-  }
-  return { ...context, selection, positions }
+  /** @type {ColumnVector} */
+  const rowOrdinals = context.rowOrdinals
+    ? selectVector(context.rowOrdinals, { type: 'indices', indices, length })
+    : { type: 'typed', values: indices, length: indices.length }
+  return { ...context, selection, rowOrdinals }
 }
 
 /**
@@ -552,13 +570,14 @@ async function visitRows(length, signal, visit) {
  * @returns {number}
  */
 function streamRowIndex(context, rowIndex) {
-  return context.rowOffset + (context.positions?.[rowIndex] ?? rowIndex)
+  const ordinal = context.rowOrdinals ? Number(valueAt(context.rowOrdinals, rowIndex)) : rowIndex
+  return context.rowOffset + ordinal
 }
 
 /**
  * @param {import('../types.js').IdentifierNode} identifier
  * @param {RelationSchema} schema
- * @returns {number | undefined}
+ * @returns {{ columnIndex: number, field?: string }[] | undefined}
  */
 function resolveIdentifier(identifier, schema) {
   const sourceName = identifier.prefix
@@ -567,15 +586,32 @@ function resolveIdentifier(identifier, schema) {
   const exact = schema.fields.findIndex(function exactName(field) {
     return field.name === sourceName
   })
-  if (exact >= 0) return exact
+  if (exact >= 0) return [{ columnIndex: exact }]
 
   if (identifier.prefix) {
-    const bareMatches = []
+    const prefix = `${identifier.prefix}.`
+    const prefixedMatches = []
+    const baseMatches = []
+    const baseSuffix = `.${identifier.prefix}`
     for (let index = 0; index < schema.fields.length; index++) {
-      if (schema.fields[index].name === identifier.name) bareMatches.push(index)
+      const fieldName = schema.fields[index].name
+      if (fieldName.startsWith(prefix)) prefixedMatches.push(index)
+      if (fieldName === identifier.prefix || fieldName.endsWith(baseSuffix)) baseMatches.push(index)
     }
-    if (bareMatches.length === 1) return bareMatches[0]
-    if (bareMatches.length > 1) return undefined
+
+    /** @type {{ columnIndex: number, field?: string }[]} */
+    const accesses = []
+    if (prefixedMatches.length === 1) {
+      accesses.push({ columnIndex: prefixedMatches[0], field: identifier.name })
+    }
+    if (baseMatches.length === 1) {
+      accesses.push({ columnIndex: baseMatches[0], field: identifier.name })
+    }
+    const bare = schema.fields.findIndex(function bareName(field) {
+      return field.name === identifier.name
+    })
+    if (bare >= 0) accesses.push({ columnIndex: bare })
+    return accesses.length > 0 ? accesses : undefined
   }
 
   const suffix = `.${identifier.name}`
@@ -583,7 +619,7 @@ function resolveIdentifier(identifier, schema) {
   for (let i = 0; i < schema.fields.length; i++) {
     if (schema.fields[i].name.endsWith(suffix)) matches.push(i)
   }
-  return matches.length === 1 ? matches[0] : undefined
+  return matches.length === 1 ? [{ columnIndex: matches[0] }] : undefined
 }
 
 /**
@@ -592,19 +628,20 @@ function resolveIdentifier(identifier, schema) {
  * @param {RowSelection} selection
  * @param {AbortSignal} [signal]
  * @param {number} [rowOffset]
- * @param {Uint32Array} [positions]
+ * @param {ColumnVector} [rowOrdinals]
  * @returns {ColumnResult}
  */
-function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0, positions) {
+function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0, rowOrdinals) {
   const length = selectedRowCount(selection)
   if (signal && length > YIELD_INTERVAL) {
-    return evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, positions)
+    return evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, rowOrdinals)
   }
   /** @type {SqlPrimitive[]} */
   const values = new Array(length)
   for (let rowIndex = 0; rowIndex < length; rowIndex++) {
     if (rowIndex % YIELD_INTERVAL === 0) signal?.throwIfAborted()
-    values[rowIndex] = kernel(vectors, rowIndex, rowOffset + (positions?.[rowIndex] ?? rowIndex))
+    const ordinal = rowOrdinals ? Number(valueAt(rowOrdinals, rowIndex)) : rowIndex
+    values[rowIndex] = kernel(vectors, rowIndex, rowOffset + ordinal)
   }
   return { type: 'values', values, length }
 }
@@ -618,10 +655,10 @@ function evaluateKernel(kernel, vectors, selection, signal, rowOffset = 0, posit
  * @param {number} length
  * @param {AbortSignal} signal
  * @param {number} rowOffset
- * @param {Uint32Array} [positions]
+ * @param {ColumnVector} [rowOrdinals]
  * @returns {Promise<ColumnVector>}
  */
-async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, positions) {
+async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, rowOrdinals) {
   /** @type {SqlPrimitive[]} */
   const values = new Array(length)
   for (let start = 0; start < length; start += YIELD_INTERVAL) {
@@ -629,7 +666,8 @@ async function evaluateKernelAsync(kernel, vectors, length, signal, rowOffset, p
     signal.throwIfAborted()
     const end = Math.min(start + YIELD_INTERVAL, length)
     for (let rowIndex = start; rowIndex < end; rowIndex++) {
-      values[rowIndex] = kernel(vectors, rowIndex, rowOffset + (positions?.[rowIndex] ?? rowIndex))
+      const ordinal = rowOrdinals ? Number(valueAt(rowOrdinals, rowIndex)) : rowIndex
+      values[rowIndex] = kernel(vectors, rowIndex, rowOffset + ordinal)
     }
   }
   return { type: 'values', values, length }

--- a/src/expression/batch.js
+++ b/src/expression/batch.js
@@ -1,0 +1,187 @@
+import { readBatchColumn, selectedRowCount, valueAt } from '../backend/batch.js'
+import { isStringFunc } from '../validation/functions.js'
+import { applyBinaryOp } from './binary.js'
+import { evaluateStringFunc } from './strings.js'
+
+/**
+ * @import { ColumnResult, ColumnVector, CompileBatchExpressionOptions, CompiledBatchExpression, CompileState, RelationSchema, RowSelection, ValueKernel } from '../internalTypes.js'
+ * @import { ExprNode, FunctionNode, SqlPrimitive } from '../types.js'
+ */
+
+/**
+ * Compiles a supported scalar expression into one column-level evaluation.
+ * Dependencies resolve at most once per batch selection; the synchronous
+ * kernel then evaluates every selected row without per-cell promises.
+ *
+ * Unsupported expressions return `undefined` so an operator can retain its
+ * existing row evaluator without changing semantics.
+ *
+ * @param {CompileBatchExpressionOptions} options
+ * @returns {CompiledBatchExpression | undefined}
+ */
+export function compileBatchExpression({ expression, schema }) {
+  /** @type {CompileState} */
+  const state = {
+    schema,
+    dependencies: [],
+    dependencyPositions: new Map(),
+  }
+  const kernel = compileValueKernel(expression, state)
+  if (!kernel) return undefined
+  const { dependencies } = state
+
+  return {
+    dependencies,
+    evaluate({ batch, selection, signal }) {
+      signal?.throwIfAborted()
+      const results = dependencies.map(function readDependency(columnIndex) {
+        return readBatchColumn({ batch, columnIndex, selection, signal })
+      })
+      const vectors = resolveVectors(results)
+      if (vectors instanceof Promise) {
+        return vectors.then(function evaluateResolved(resolved) {
+          signal?.throwIfAborted()
+          return evaluateKernel(kernel, resolved, selection, signal)
+        })
+      }
+      return evaluateKernel(kernel, vectors, selection, signal)
+    },
+  }
+}
+
+/**
+ * @param {ExprNode} node
+ * @param {CompileState} state
+ * @returns {ValueKernel | undefined}
+ */
+function compileValueKernel(node, state) {
+  if (node.type === 'literal') {
+    return function literalValue() { return node.value }
+  }
+
+  if (node.type === 'identifier') {
+    const columnIndex = resolveIdentifier(node, state.schema)
+    if (columnIndex === undefined) return undefined
+    let dependencyPosition = state.dependencyPositions.get(columnIndex)
+    if (dependencyPosition === undefined) {
+      dependencyPosition = state.dependencies.length
+      state.dependencies.push(columnIndex)
+      state.dependencyPositions.set(columnIndex, dependencyPosition)
+    }
+    return function identifierValue(vectors, rowIndex) {
+      return valueAt(vectors[dependencyPosition], rowIndex)
+    }
+  }
+
+  if (node.type === 'unary') {
+    const argument = compileValueKernel(node.argument, state)
+    if (!argument) return undefined
+    return function unaryValue(vectors, rowIndex) {
+      const value = argument(vectors, rowIndex)
+      if (node.op === '-') return value == null ? null : -value
+      if (node.op === 'NOT') return value == null ? null : !value
+      if (node.op === 'IS NULL') return value == null
+      return value != null
+    }
+  }
+
+  if (node.type === 'binary') {
+    if (node.left.type === 'interval' || node.right.type === 'interval') return undefined
+    const left = compileValueKernel(node.left, state)
+    const right = compileValueKernel(node.right, state)
+    if (!left || !right) return undefined
+    return function binaryValue(vectors, rowIndex) {
+      const leftValue = left(vectors, rowIndex)
+      if (node.op === 'AND' && leftValue != null && !leftValue) return false
+      if (node.op === 'OR' && leftValue != null && Boolean(leftValue)) return true
+      const rightValue = right(vectors, rowIndex)
+      return applyBinaryOp(node.op, leftValue, rightValue)
+    }
+  }
+
+  if (node.type === 'function') {
+    return compileFunctionKernel(node, state)
+  }
+
+  return undefined
+}
+
+/**
+ * @param {FunctionNode} node
+ * @param {CompileState} state
+ * @returns {ValueKernel | undefined}
+ */
+function compileFunctionKernel(node, state) {
+  const funcName = node.funcName.toUpperCase()
+  if (!isStringFunc(funcName) || node.distinct || node.filter) return undefined
+  /** @type {ValueKernel[]} */
+  const arguments_ = []
+  for (const argumentNode of node.args) {
+    const argument = compileValueKernel(argumentNode, state)
+    if (!argument) return undefined
+    arguments_.push(argument)
+  }
+  return function stringFunctionValue(vectors, rowIndex) {
+    const args = arguments_.map(function argumentValue(argument) {
+      return argument(vectors, rowIndex)
+    })
+    return evaluateStringFunc({ funcName, node, args, rowIndex: rowIndex + 1 })
+  }
+}
+
+/**
+ * @param {import('../types.js').IdentifierNode} identifier
+ * @param {RelationSchema} schema
+ * @returns {number | undefined}
+ */
+function resolveIdentifier(identifier, schema) {
+  const sourceName = identifier.prefix
+    ? `${identifier.prefix}.${identifier.name}`
+    : identifier.name
+  const exact = schema.fields.findIndex(function exactName(field) {
+    return field.name === sourceName
+  })
+  if (exact >= 0) return exact
+
+  const suffix = `.${identifier.name}`
+  const matches = []
+  for (let i = 0; i < schema.fields.length; i++) {
+    if (schema.fields[i].name.endsWith(suffix)) matches.push(i)
+  }
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+/**
+ * @param {ValueKernel} kernel
+ * @param {ColumnVector[]} vectors
+ * @param {RowSelection} selection
+ * @param {AbortSignal} [signal]
+ * @returns {ColumnVector}
+ */
+function evaluateKernel(kernel, vectors, selection, signal) {
+  const length = selectedRowCount(selection)
+  /** @type {SqlPrimitive[]} */
+  const values = new Array(length)
+  for (let rowIndex = 0; rowIndex < length; rowIndex++) {
+    if (rowIndex % 4000 === 0) signal?.throwIfAborted()
+    values[rowIndex] = kernel(vectors, rowIndex)
+  }
+  return { type: 'values', values, length }
+}
+
+/**
+ * @param {ColumnResult[]} results
+ * @returns {ColumnVector[] | Promise<ColumnVector[]>}
+ */
+function resolveVectors(results) {
+  if (results.some(function isPromise(result) { return result instanceof Promise })) {
+    return Promise.all(results)
+  }
+  /** @type {ColumnVector[]} */
+  const vectors = []
+  for (const result of results) {
+    if (result instanceof Promise) throw new Error('Unexpected asynchronous column result')
+    vectors.push(result)
+  }
+  return vectors
+}

--- a/src/expression/evaluate.js
+++ b/src/expression/evaluate.js
@@ -1,5 +1,5 @@
 import { executeStatement } from '../execute/execute.js'
-import { isPlainObject, keyify, sqlEquals, stringify } from '../execute/utils.js'
+import { isPlainObject, keyify, sqlEquals } from '../execute/utils.js'
 import { yieldToEventLoop } from '../execute/yield.js'
 import { ArgValueError, ExecutionError } from '../validation/executionErrors.js'
 import { isAggregateFunc, isMathFunc, isRegexpFunc, isSpatialFunc, isStringFunc } from '../validation/functions.js'
@@ -7,9 +7,10 @@ import { UnknownFunctionError } from '../validation/parseErrors.js'
 import { ColumnNotFoundError } from '../validation/tables.js'
 import { derivedAlias } from './alias.js'
 import { applyBinaryOp } from './binary.js'
-import { applyIntervalToDate, dateDiff, dateTrunc, extractField, toDate } from './date.js'
+import { applyIntervalToDate, dateDiff, dateTrunc, extractField } from './date.js'
 import { evaluateMathFunc } from './math.js'
 import { evaluateRegexpFunc } from './regexp.js'
+import { applyCast, evaluateJsonExtract } from './scalar.js'
 import { evaluateSpatialFunc } from '../spatial/spatial.js'
 import { evaluateStringFunc } from './strings.js'
 
@@ -669,60 +670,7 @@ export async function evaluateExpr({ node, row, rowIndex, rows, context }) {
     }
 
     if (funcName === 'JSON_VALUE' || funcName === 'JSON_QUERY' || funcName === 'JSON_EXTRACT' || funcName === 'JSON_EXTRACT_STRING') {
-      let jsonArg = args[0]
-      const pathArg = args[1]
-      if (jsonArg == null || pathArg == null) return null
-
-      // Parse JSON if string, otherwise use directly
-      if (typeof jsonArg === 'string') {
-        try {
-          jsonArg = JSON.parse(jsonArg)
-        } catch {
-          throw new ArgValueError({
-            ...node,
-            message: 'invalid JSON string',
-            hint: 'First argument must be valid JSON.',
-            rowIndex,
-          })
-        }
-      }
-      if (typeof jsonArg !== 'object' || jsonArg instanceof Date) {
-        throw new ArgValueError({
-          ...node,
-          message: `first argument must be JSON string or object, got ${typeof jsonArg}`,
-          rowIndex,
-        })
-      }
-
-      // Parse path ("$.foo.bar[0].baz" or "foo.bar[0]")
-      const path = String(pathArg)
-      const normalizedPath = path.startsWith('$') ? path.slice(1) : path
-
-      // Navigate the path
-      let current = jsonArg
-      const segments = normalizedPath.match(/\.?([^.[]+)|\[(\d+)\]/g) || []
-      for (const segment of segments) {
-        if (current == null) return null
-        if (segment.startsWith('[')) {
-          // Array index access
-          const index = parseInt(segment.slice(1, -1), 10)
-          if (!Array.isArray(current)) return null
-          current = current[index]
-        } else {
-          // Property access
-          const key = segment.startsWith('.') ? segment.slice(1) : segment
-          if (typeof current !== 'object' || Array.isArray(current)) return null
-          current = current[key]
-        }
-      }
-
-      if (current == null) return null
-      // JSON_EXTRACT_STRING returns text: unquoted scalars, JSON text for objects and arrays
-      if (funcName === 'JSON_EXTRACT_STRING') {
-        if (typeof current === 'object') return JSON.stringify(current)
-        return String(current)
-      }
-      return current
+      return evaluateJsonExtract({ funcName, node, args, rowIndex })
     }
 
     // Check user-defined functions (case-insensitive lookup)
@@ -739,45 +687,7 @@ export async function evaluateExpr({ node, row, rowIndex, rows, context }) {
 
   if (node.type === 'cast') {
     const val = await evaluateExpr({ node: node.expr, row, rowIndex, rows, context })
-    if (val == null) return null
-    const { toType } = node
-    if (toType === 'TEXT' || toType === 'STRING' || toType === 'VARCHAR') {
-      if (typeof val === 'object') return stringify(val)
-      return String(val)
-    }
-    // Can only cast primitives (and Dates) to other primitive types
-    if (typeof val === 'object' && !(val instanceof Date)) {
-      if (node.tryCast) return null
-      throw new ExecutionError({ message: `Cannot CAST object to ${toType}`, rowIndex, ...node })
-    }
-    if (toType === 'INTEGER' || toType === 'INT') {
-      const num = Number(val)
-      if (isNaN(num)) return null
-      return Math.trunc(num)
-    }
-    if (toType === 'BIGINT') {
-      if (typeof val === 'bigint') return val
-      const num = Number(val)
-      // NaN and Infinity have no bigint representation
-      if (!isFinite(num)) return null
-      return BigInt(Math.trunc(num))
-    }
-    if (toType === 'FLOAT' || toType === 'REAL' || toType === 'DOUBLE') {
-      const num = Number(val)
-      if (isNaN(num)) return null
-      return num
-    }
-    if (toType === 'BOOLEAN' || toType === 'BOOL') {
-      return Boolean(val)
-    }
-    if (toType === 'TIMESTAMP') {
-      if (typeof val === 'number' || typeof val === 'bigint') {
-        const date = new Date(Number(val))
-        if (isNaN(date.getTime())) return null
-        return date
-      }
-      return toDate(val)
-    }
+    return applyCast(node, val, rowIndex)
   }
 
   // IN and NOT IN with value lists. IN is a chain of OR'd equalities, so it

--- a/src/expression/scalar.js
+++ b/src/expression/scalar.js
@@ -1,0 +1,105 @@
+import { stringify } from '../execute/utils.js'
+import { ArgValueError, ExecutionError } from '../validation/executionErrors.js'
+import { toDate } from './date.js'
+
+/**
+ * @import { CastNode, FunctionNode, SqlPrimitive } from '../types.js'
+ */
+
+/**
+ * Applies a scalar CAST without requiring a row evaluator.
+ *
+ * @param {CastNode} node
+ * @param {SqlPrimitive} value
+ * @param {number} [rowIndex]
+ * @returns {SqlPrimitive}
+ */
+export function applyCast(node, value, rowIndex) {
+  if (value == null) return null
+  const { toType } = node
+  if (toType === 'TEXT' || toType === 'STRING' || toType === 'VARCHAR') {
+    return typeof value === 'object' ? stringify(value) : String(value)
+  }
+  if (typeof value === 'object' && !(value instanceof Date)) {
+    if (node.tryCast) return null
+    throw new ExecutionError({ message: `Cannot CAST object to ${toType}`, rowIndex, ...node })
+  }
+  if (toType === 'INTEGER' || toType === 'INT') {
+    const number = Number(value)
+    return isNaN(number) ? null : Math.trunc(number)
+  }
+  if (toType === 'BIGINT') {
+    if (typeof value === 'bigint') return value
+    const number = Number(value)
+    return isFinite(number) ? BigInt(Math.trunc(number)) : null
+  }
+  if (toType === 'FLOAT' || toType === 'REAL' || toType === 'DOUBLE') {
+    const number = Number(value)
+    return isNaN(number) ? null : number
+  }
+  if (toType === 'BOOLEAN' || toType === 'BOOL') return Boolean(value)
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    const date = new Date(Number(value))
+    return isNaN(date.getTime()) ? null : date
+  }
+  return toDate(value)
+}
+
+/**
+ * Applies the JSON extraction functions shared by row and batch evaluation.
+ *
+ * @param {object} options
+ * @param {string} options.funcName
+ * @param {FunctionNode} options.node
+ * @param {SqlPrimitive[]} options.args
+ * @param {number} [options.rowIndex]
+ * @returns {SqlPrimitive}
+ */
+export function evaluateJsonExtract({ funcName, node, args, rowIndex }) {
+  let json = args[0]
+  const pathArg = args[1]
+  if (json == null || pathArg == null) return null
+
+  if (typeof json === 'string') {
+    try {
+      json = JSON.parse(json)
+    } catch {
+      throw new ArgValueError({
+        ...node,
+        message: 'invalid JSON string',
+        hint: 'First argument must be valid JSON.',
+        rowIndex,
+      })
+    }
+  }
+  if (typeof json !== 'object' || json instanceof Date) {
+    throw new ArgValueError({
+      ...node,
+      message: `first argument must be JSON string or object, got ${typeof json}`,
+      rowIndex,
+    })
+  }
+
+  const path = String(pathArg)
+  const normalized = path.startsWith('$') ? path.slice(1) : path
+  /** @type {any} */
+  let current = json
+  const segments = normalized.match(/\.?([^.[]+)|\[(\d+)\]/g) || []
+  for (const segment of segments) {
+    if (current == null) return null
+    if (segment.startsWith('[')) {
+      if (!Array.isArray(current)) return null
+      current = current[parseInt(segment.slice(1, -1), 10)]
+    } else {
+      if (typeof current !== 'object' || Array.isArray(current)) return null
+      const key = segment.startsWith('.') ? segment.slice(1) : segment
+      current = current[key]
+    }
+  }
+
+  if (current == null) return null
+  if (funcName === 'JSON_EXTRACT_STRING') {
+    return typeof current === 'object' ? JSON.stringify(current) : String(current)
+  }
+  return current
+}

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -67,6 +67,7 @@ export interface ColumnEvaluationRequest {
   selection: RowSelection
   signal?: AbortSignal
   rowOffset?: number
+  rowOrdinals?: ColumnVector
 }
 
 export type EvaluateColumn = (request: ColumnEvaluationRequest) => ColumnResult
@@ -87,6 +88,19 @@ export type ValueKernel = (
   streamRowIndex: number,
 ) => SqlPrimitive
 
+export interface EvaluationContext {
+  batch: AsyncBatch
+  selection: RowSelection
+  signal?: AbortSignal
+  rowOffset: number
+  rowOrdinals?: ColumnVector
+}
+
+export interface CompiledEvaluator {
+  dependencies: readonly number[]
+  evaluate(context: EvaluationContext): ColumnResult
+}
+
 export interface CompileState {
   dependencies: number[]
   dependencyPositions: Map<number, number>
@@ -97,19 +111,6 @@ export interface BatchAggregateInputs {
   keys: CompiledBatchExpression[]
   filters: (CompiledBatchExpression | undefined)[]
   args: (CompiledBatchExpression | undefined)[]
-}
-
-export interface EvaluationContext {
-  batch: AsyncBatch
-  selection: RowSelection
-  signal?: AbortSignal
-  rowOffset: number
-  positions?: Uint32Array
-}
-
-export interface CompiledEvaluator {
-  dependencies: readonly number[]
-  evaluate(context: EvaluationContext): ColumnResult
 }
 
 export type BatchProjection =
@@ -124,6 +125,7 @@ export type BatchColumn =
       type: 'computed'
       input: AsyncBatch
       dependencies: readonly number[]
+      rowOrdinals: ColumnVector
       evaluate: EvaluateColumn
     }
 

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -93,6 +93,12 @@ export interface CompileState {
   schema: RelationSchema
 }
 
+export interface BatchAggregateInputs {
+  keys: CompiledBatchExpression[]
+  filters: (CompiledBatchExpression | undefined)[]
+  args: (CompiledBatchExpression | undefined)[]
+}
+
 export type BatchProjection =
   | { type: 'column', columnIndex: number }
   | { type: 'constant', value: SqlPrimitive }

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -99,6 +99,19 @@ export interface BatchAggregateInputs {
   args: (CompiledBatchExpression | undefined)[]
 }
 
+export interface EvaluationContext {
+  batch: AsyncBatch
+  selection: RowSelection
+  signal?: AbortSignal
+  rowOffset: number
+  positions?: Uint32Array
+}
+
+export interface CompiledEvaluator {
+  dependencies: readonly number[]
+  evaluate(context: EvaluationContext): ColumnResult
+}
+
 export type BatchProjection =
   | { type: 'column', columnIndex: number }
   | { type: 'constant', value: SqlPrimitive }

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -1,4 +1,4 @@
-import type { AsyncRow, QueryResults, SqlPrimitive } from './types.js'
+import type { AsyncRow, ExprNode, QueryResults, SqlPrimitive } from './types.js'
 
 export type FieldId = number
 
@@ -69,6 +69,24 @@ export interface ColumnEvaluationRequest {
 }
 
 export type EvaluateColumn = (request: ColumnEvaluationRequest) => ColumnResult
+
+export interface CompileBatchExpressionOptions {
+  expression: ExprNode
+  schema: RelationSchema
+}
+
+export interface CompiledBatchExpression {
+  dependencies: readonly number[]
+  evaluate: EvaluateColumn
+}
+
+export type ValueKernel = (vectors: ColumnVector[], rowIndex: number) => SqlPrimitive
+
+export interface CompileState {
+  dependencies: number[]
+  dependencyPositions: Map<number, number>
+  schema: RelationSchema
+}
 
 export type BatchColumn =
   | { type: 'loaded', vector: ColumnVector }

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -1,0 +1,107 @@
+import type { AsyncRow, QueryResults, SqlPrimitive } from './types.js'
+
+export type FieldId = number
+
+export type SqlType =
+  | { type: 'unknown' }
+  | { type: 'string' }
+  | { type: 'number' }
+  | { type: 'bigint' }
+  | { type: 'boolean' }
+  | { type: 'date' }
+  | { type: 'array', items: SqlType }
+  | { type: 'struct', fields: readonly Field[] }
+
+export interface Field {
+  id: FieldId
+  name: string
+  dataType: SqlType
+  nullable: boolean
+}
+
+export interface RelationSchema {
+  fields: readonly Field[]
+}
+
+export interface RowRange {
+  start: number
+  end: number
+}
+
+export type RowSelection =
+  | { type: 'all', length: number }
+  | { type: 'range', start: number, end: number, length: number }
+  | { type: 'ranges', ranges: readonly RowRange[], length: number }
+  | { type: 'indices', indices: Uint32Array, length: number }
+  | { type: 'bitmap', values: Uint8Array, length: number }
+
+export type NumericArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array
+
+export type ColumnVector =
+  | { type: 'values', values: readonly SqlPrimitive[], length: number }
+  | { type: 'typed', values: NumericArray, validity?: Uint8Array, length: number }
+  | { type: 'constant', value: SqlPrimitive, length: number }
+  | { type: 'selected', source: ColumnVector, selection: RowSelection, length: number }
+
+export interface ColumnReadRequest {
+  selection: RowSelection
+  signal?: AbortSignal
+}
+
+export type ColumnResult = ColumnVector | Promise<ColumnVector>
+export type ReadColumn = (request: ColumnReadRequest) => ColumnResult
+
+export interface ColumnEvaluationRequest {
+  batch: AsyncBatch
+  selection: RowSelection
+  signal?: AbortSignal
+}
+
+export type EvaluateColumn = (request: ColumnEvaluationRequest) => ColumnResult
+
+export type BatchColumn =
+  | { type: 'loaded', vector: ColumnVector }
+  | { type: 'source', read: ReadColumn }
+  | { type: 'computed', input: AsyncBatch, evaluate: EvaluateColumn }
+
+export interface AsyncBatch {
+  schema: RelationSchema
+  selection: RowSelection
+  columns: readonly BatchColumn[]
+}
+
+export interface ReadBatchColumnOptions {
+  batch: AsyncBatch
+  columnIndex: number
+  selection?: RowSelection
+  signal?: AbortSignal
+}
+
+export interface RowsToBatchesOptions {
+  batchRows?: number
+  signal?: AbortSignal
+}
+
+export interface InternalBatchResults {
+  schema: RelationSchema
+  batches(): AsyncIterable<AsyncBatch>
+  signal?: AbortSignal
+}
+
+export interface RegisteredBatchResults {
+  results: QueryResults
+  batchResults: InternalBatchResults
+}
+
+export type { AsyncRow, SqlPrimitive }

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -1,39 +1,9 @@
-import type { AsyncRow, ExprNode, QueryResults, SqlPrimitive } from './types.js'
-
-export type FieldId = number
-
-export type SqlType =
-  | { type: 'unknown' }
-  | { type: 'string' }
-  | { type: 'number' }
-  | { type: 'bigint' }
-  | { type: 'boolean' }
-  | { type: 'date' }
-  | { type: 'array', items: SqlType }
-  | { type: 'struct', fields: readonly Field[] }
-
-export interface Field {
-  id: FieldId
-  name: string
-  dataType: SqlType
-  nullable: boolean
-}
-
-export interface RelationSchema {
-  fields: readonly Field[]
-}
-
-export interface RowRange {
-  start: number
-  end: number
-}
+import type { SqlPrimitive } from './types.js'
 
 export type RowSelection =
   | { type: 'all', length: number }
   | { type: 'range', start: number, end: number, length: number }
-  | { type: 'ranges', ranges: readonly RowRange[], length: number }
   | { type: 'indices', indices: Uint32Array, length: number }
-  | { type: 'bitmap', values: Uint8Array, length: number }
 
 export type NumericArray =
   | Int8Array
@@ -62,7 +32,7 @@ export interface ColumnReadRequest {
 export type ColumnResult = ColumnVector | Promise<ColumnVector>
 export type ReadColumn = (request: ColumnReadRequest) => ColumnResult
 
-export interface ColumnEvaluationRequest {
+export interface EvaluationContext {
   batch: AsyncBatch
   selection: RowSelection
   signal?: AbortSignal
@@ -70,16 +40,8 @@ export interface ColumnEvaluationRequest {
   rowOrdinals?: ColumnVector
 }
 
-export type EvaluateColumn = (request: ColumnEvaluationRequest) => ColumnResult
-
-export interface CompileBatchExpressionOptions {
-  expression: ExprNode
-  schema: RelationSchema
-}
-
 export interface CompiledBatchExpression {
-  dependencies: readonly number[]
-  evaluate: EvaluateColumn
+  evaluate(context: EvaluationContext): ColumnResult
 }
 
 export type ValueKernel = (
@@ -88,23 +50,10 @@ export type ValueKernel = (
   streamRowIndex: number,
 ) => SqlPrimitive
 
-export interface EvaluationContext {
-  batch: AsyncBatch
-  selection: RowSelection
-  signal?: AbortSignal
-  rowOffset: number
-  rowOrdinals?: ColumnVector
-}
-
-export interface CompiledEvaluator {
-  dependencies: readonly number[]
-  evaluate(context: EvaluationContext): ColumnResult
-}
-
 export interface CompileState {
   dependencies: number[]
   dependencyPositions: Map<number, number>
-  schema: RelationSchema
+  columns: readonly string[]
 }
 
 export interface BatchAggregateInputs {
@@ -119,18 +68,18 @@ export type BatchProjection =
   | { type: 'expression', expression: CompiledBatchExpression }
 
 export type BatchColumn =
-  | { type: 'loaded', vector: ColumnVector }
+  | ColumnVector
   | { type: 'source', read: ReadColumn }
   | {
       type: 'computed'
       input: AsyncBatch
-      dependencies: readonly number[]
+      expression: CompiledBatchExpression
+      rowOffset: number
       rowOrdinals: ColumnVector
-      evaluate: EvaluateColumn
     }
 
 export interface AsyncBatch {
-  schema: RelationSchema
+  columnNames: string[]
   selection: RowSelection
   columns: readonly BatchColumn[]
 }
@@ -148,14 +97,7 @@ export interface RowsToBatchesOptions {
 }
 
 export interface InternalBatchResults {
-  schema: RelationSchema
+  columns: string[]
   batches(): AsyncIterable<AsyncBatch>
   signal?: AbortSignal
 }
-
-export interface RegisteredBatchResults {
-  results: QueryResults
-  batchResults: InternalBatchResults
-}
-
-export type { AsyncRow, SqlPrimitive }

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -88,10 +88,20 @@ export interface CompileState {
   schema: RelationSchema
 }
 
+export type BatchProjection =
+  | { type: 'column', columnIndex: number }
+  | { type: 'constant', value: SqlPrimitive }
+  | { type: 'expression', expression: CompiledBatchExpression }
+
 export type BatchColumn =
   | { type: 'loaded', vector: ColumnVector }
   | { type: 'source', read: ReadColumn }
-  | { type: 'computed', input: AsyncBatch, evaluate: EvaluateColumn }
+  | {
+      type: 'computed'
+      input: AsyncBatch
+      dependencies: readonly number[]
+      evaluate: EvaluateColumn
+    }
 
 export interface AsyncBatch {
   schema: RelationSchema

--- a/src/internalTypes.d.ts
+++ b/src/internalTypes.d.ts
@@ -66,6 +66,7 @@ export interface ColumnEvaluationRequest {
   batch: AsyncBatch
   selection: RowSelection
   signal?: AbortSignal
+  rowOffset?: number
 }
 
 export type EvaluateColumn = (request: ColumnEvaluationRequest) => ColumnResult
@@ -80,7 +81,11 @@ export interface CompiledBatchExpression {
   evaluate: EvaluateColumn
 }
 
-export type ValueKernel = (vectors: ColumnVector[], rowIndex: number) => SqlPrimitive
+export type ValueKernel = (
+  vectors: ColumnVector[],
+  rowIndex: number,
+  streamRowIndex: number,
+) => SqlPrimitive
 
 export interface CompileState {
   dependencies: number[]

--- a/test/backend/batch.test.js
+++ b/test/backend/batch.test.js
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  composeSelections,
+  readBatchColumn,
+  selectBatch,
+  selectVector,
+  selectedRowCount,
+  valueAt,
+} from '../../src/backend/batch.js'
+
+/**
+ * @import { AsyncBatch, ColumnVector, ReadColumn, RelationSchema } from '../../src/internalTypes.js'
+ */
+
+/** @type {RelationSchema} */
+const schema = {
+  fields: [
+    { id: 0, name: 'value', dataType: { type: 'number' }, nullable: false },
+  ],
+}
+
+describe('row selections', () => {
+  it('counts every concrete selection representation', () => {
+    expect(selectedRowCount({ type: 'all', length: 5 })).toBe(5)
+    expect(selectedRowCount({ type: 'range', start: 1, end: 4, length: 5 })).toBe(3)
+    expect(selectedRowCount({
+      type: 'ranges',
+      ranges: [{ start: 0, end: 2 }, { start: 4, end: 5 }],
+      length: 5,
+    })).toBe(3)
+    expect(selectedRowCount({
+      type: 'indices',
+      indices: new Uint32Array([1, 4]),
+      length: 5,
+    })).toBe(2)
+    expect(selectedRowCount({
+      type: 'bitmap',
+      values: new Uint8Array([0, 1, 0, 1, 1]),
+      length: 5,
+    })).toBe(3)
+  })
+
+  it('preserves ranges while composing contiguous selections', () => {
+    expect(composeSelections(
+      { type: 'range', start: 10, end: 20, length: 30 },
+      { type: 'range', start: 2, end: 5, length: 10 }
+    )).toEqual({ type: 'range', start: 12, end: 15, length: 30 })
+  })
+
+  it('composes sparse selections into base-domain indices', () => {
+    expect(composeSelections(
+      { type: 'indices', indices: new Uint32Array([2, 4, 8, 9]), length: 10 },
+      { type: 'indices', indices: new Uint32Array([1, 3]), length: 4 }
+    )).toEqual({
+      type: 'indices',
+      indices: new Uint32Array([4, 9]),
+      length: 10,
+    })
+  })
+
+  it('rejects selections over the wrong domain', () => {
+    expect(() => composeSelections(
+      { type: 'range', start: 2, end: 5, length: 10 },
+      { type: 'all', length: 10 }
+    )).toThrow('Cannot compose selection of length 10 over 3 rows')
+  })
+})
+
+describe('column vectors', () => {
+  it('reads typed nulls through a zero-copy selected view', () => {
+    /** @type {ColumnVector} */
+    const source = {
+      type: 'typed',
+      values: new Int32Array([10, 20, 30, 40]),
+      validity: new Uint8Array([1, 0, 1, 1]),
+      length: 4,
+    }
+    const vector = selectVector(source, {
+      type: 'indices',
+      indices: new Uint32Array([3, 1]),
+      length: 4,
+    })
+
+    expect(vector.type).toBe('selected')
+    expect(vector.type === 'selected' && vector.source).toBe(source)
+    expect(valueAt(vector, 0)).toBe(40)
+    expect(valueAt(vector, 1)).toBeNull()
+  })
+
+  it('composes nested selected views', () => {
+    /** @type {ColumnVector} */
+    const source = { type: 'values', values: ['a', 'b', 'c', 'd'], length: 4 }
+    const first = selectVector(source, {
+      type: 'indices',
+      indices: new Uint32Array([3, 1, 2]),
+      length: 4,
+    })
+    const second = selectVector(first, {
+      type: 'range',
+      start: 1,
+      end: 3,
+      length: 3,
+    })
+
+    expect(valueAt(second, 0)).toBe('b')
+    expect(valueAt(second, 1)).toBe('c')
+  })
+})
+
+describe('async batches', () => {
+  it('keeps source reads lazy and memoizes a selected result', async () => {
+    /** @type {ReadColumn} */
+    function readColumn({ selection }) {
+      return Promise.resolve({
+        type: 'constant',
+        value: 7,
+        length: selectedRowCount(selection),
+      })
+    }
+    const read = vi.fn(readColumn)
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 5 },
+      columns: [{ type: 'source', read }],
+    }
+
+    expect(read).not.toHaveBeenCalled()
+    const selected = selectBatch(batch, {
+      type: 'range',
+      start: 1,
+      end: 3,
+      length: 5,
+    })
+    const first = readBatchColumn({ batch: selected, columnIndex: 0 })
+    const second = readBatchColumn({ batch: selected, columnIndex: 0 })
+
+    expect(first).toBe(second)
+    expect(await first).toEqual({ type: 'constant', value: 7, length: 2 })
+    expect(read).toHaveBeenCalledTimes(1)
+    expect(read).toHaveBeenCalledWith({
+      selection: { type: 'range', start: 1, end: 3, length: 5 },
+      signal: undefined,
+    })
+  })
+
+  it('does not turn a synchronous loaded read into a promise', () => {
+    /** @type {ColumnVector} */
+    const vector = { type: 'values', values: [1, 2, 3], length: 3 }
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 3 },
+      columns: [{ type: 'loaded', vector }],
+    }
+
+    expect(readBatchColumn({ batch, columnIndex: 0 })).toBe(vector)
+  })
+
+  it('validates deferred vector alignment', async () => {
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 3 },
+      columns: [{
+        type: 'source',
+        read() {
+          return Promise.resolve({ type: 'values', values: [1], length: 1 })
+        },
+      }],
+    }
+
+    await expect(readBatchColumn({ batch, columnIndex: 0 })).rejects.toThrow(
+      'Column returned 1 rows, expected 3'
+    )
+  })
+
+  it('does not retain a rejected signal-bound column read', async () => {
+    const first = new AbortController()
+    const second = new AbortController()
+    /** @type {ReadColumn} */
+    function readColumn({ selection, signal }) {
+      if (signal === second.signal) {
+        return Promise.resolve({
+          type: 'constant',
+          value: 2,
+          length: selectedRowCount(selection),
+        })
+      }
+      return new Promise(function waitForAbort(_resolve, reject) {
+        signal?.addEventListener('abort', function rejectAbort() { reject(signal.reason) }, { once: true })
+      })
+    }
+    const read = vi.fn(readColumn)
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 1 },
+      columns: [{ type: 'source', read }],
+    }
+
+    const rejected = readBatchColumn({ batch, columnIndex: 0, signal: first.signal })
+    const rejection = expect(rejected).rejects.toThrow('first read aborted')
+    first.abort(new Error('first read aborted'))
+    await rejection
+
+    await expect(readBatchColumn({
+      batch,
+      columnIndex: 0,
+      signal: second.signal,
+    })).resolves.toEqual({ type: 'constant', value: 2, length: 1 })
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/backend/batch.test.js
+++ b/test/backend/batch.test.js
@@ -9,35 +9,20 @@ import {
 } from '../../src/backend/batch.js'
 
 /**
- * @import { AsyncBatch, ColumnVector, ReadColumn, RelationSchema } from '../../src/internalTypes.js'
+ * @import { AsyncBatch, ColumnVector, ReadColumn } from '../../src/internalTypes.js'
  */
 
-/** @type {RelationSchema} */
-const schema = {
-  fields: [
-    { id: 0, name: 'value', dataType: { type: 'number' }, nullable: false },
-  ],
-}
+const schema = ['value']
 
 describe('row selections', () => {
-  it('counts every concrete selection representation', () => {
+  it('counts every selection representation', () => {
     expect(selectedRowCount({ type: 'all', length: 5 })).toBe(5)
     expect(selectedRowCount({ type: 'range', start: 1, end: 4, length: 5 })).toBe(3)
-    expect(selectedRowCount({
-      type: 'ranges',
-      ranges: [{ start: 0, end: 2 }, { start: 4, end: 5 }],
-      length: 5,
-    })).toBe(3)
     expect(selectedRowCount({
       type: 'indices',
       indices: new Uint32Array([1, 4]),
       length: 5,
     })).toBe(2)
-    expect(selectedRowCount({
-      type: 'bitmap',
-      values: new Uint8Array([0, 1, 0, 1, 1]),
-      length: 5,
-    })).toBe(3)
   })
 
   it('preserves ranges while composing contiguous selections', () => {
@@ -120,7 +105,7 @@ describe('async batches', () => {
     const read = vi.fn(readColumn)
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 5 },
       columns: [{ type: 'source', read }],
     }
@@ -149,9 +134,9 @@ describe('async batches', () => {
     const vector = { type: 'values', values: [1, 2, 3], length: 3 }
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 3 },
-      columns: [{ type: 'loaded', vector }],
+      columns: [vector],
     }
 
     expect(readBatchColumn({ batch, columnIndex: 0 })).toBe(vector)
@@ -160,7 +145,7 @@ describe('async batches', () => {
   it('validates deferred vector alignment', async () => {
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 3 },
       columns: [{
         type: 'source',
@@ -194,7 +179,7 @@ describe('async batches', () => {
     const read = vi.fn(readColumn)
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 1 },
       columns: [{ type: 'source', read }],
     }

--- a/test/backend/batchAdapters.test.js
+++ b/test/backend/batchAdapters.test.js
@@ -2,20 +2,14 @@ import { describe, expect, it, vi } from 'vitest'
 import { selectedRowCount } from '../../src/backend/batch.js'
 import { collect } from '../../src/execute/utils.js'
 import { batchesToRows, rowsToBatches } from '../../src/backend/batchAdapters.js'
-import { registerBatchResults } from '../../src/execute/batchResults.js'
+import { batchResult } from '../../src/execute/batchResults.js'
 
 /**
- * @import { AsyncBatch, ColumnVector, ReadColumn, RelationSchema } from '../../src/internalTypes.js'
+ * @import { AsyncBatch, ColumnVector, ReadColumn } from '../../src/internalTypes.js'
  * @import { AsyncRow } from '../../src/types.js'
  */
 
-/** @type {RelationSchema} */
-const schema = {
-  fields: [
-    { id: 0, name: 'id', dataType: { type: 'number' }, nullable: false },
-    { id: 1, name: 'name', dataType: { type: 'string' }, nullable: false },
-  ],
-}
+const schema = ['id', 'name']
 
 describe('batch adapters', () => {
   it('materializes legacy rows into bounded aligned batches', async () => {
@@ -34,9 +28,8 @@ describe('batch adapters', () => {
     expect(batches.map(function summarize(batch) {
       return {
         rowCount: selectedRowCount(batch.selection),
-        ids: batch.columns[0].type === 'loaded'
-          && batch.columns[0].vector.type === 'values'
-          ? batch.columns[0].vector.values
+        ids: batch.columns[0].type === 'values'
+          ? batch.columns[0].values
           : [],
       }
     })).toEqual([
@@ -55,7 +48,7 @@ describe('batch adapters', () => {
     const read = vi.fn(readColumn)
     /** @type {AsyncBatch} */
     const batch = {
-      schema: { fields: [schema.fields[0]] },
+      columnNames: [schema[0]],
       selection: { type: 'all', length: 2 },
       columns: [{ type: 'source', read }],
     }
@@ -76,7 +69,7 @@ describe('batch adapters', () => {
   it('adapts loaded columns through the batch selection', async () => {
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: {
         type: 'indices',
         indices: new Uint32Array([2, 0]),
@@ -84,12 +77,14 @@ describe('batch adapters', () => {
       },
       columns: [
         {
-          type: 'loaded',
-          vector: { type: 'values', values: [10, 20, 30], length: 3 },
+          type: 'values',
+          values: [10, 20, 30],
+          length: 3,
         },
         {
-          type: 'loaded',
-          vector: { type: 'values', values: ['a', 'b', 'c'], length: 3 },
+          type: 'values',
+          values: ['a', 'b', 'c'],
+          length: 3,
         },
       ],
     }
@@ -111,7 +106,7 @@ describe('batch adapters', () => {
   it('collects native batches without consuming the row adapter', async () => {
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: {
         type: 'indices',
         indices: new Uint32Array([2, 0]),
@@ -119,33 +114,30 @@ describe('batch adapters', () => {
       },
       columns: [
         {
-          type: 'loaded',
-          vector: { type: 'values', values: [10, 20, 30], length: 3 },
+          type: 'values',
+          values: [10, 20, 30],
+          length: 3,
         },
         {
-          type: 'loaded',
-          vector: { type: 'values', values: ['a', 'b', 'c'], length: 3 },
+          type: 'values',
+          values: ['a', 'b', 'c'],
+          length: 3,
         },
       ],
     }
-    const rows = vi.fn(function rows() {
-      throw new Error('row adapter should not be consumed')
-    })
-
-    const results = {
+    const results = batchResult({
       columns: ['id', 'name'],
-      rows,
-    }
-    registerBatchResults(results, {
-      schema,
       async *batches() { yield batch },
+    })
+    results.rows = vi.fn(function rows() {
+      throw new Error('row adapter should not be consumed')
     })
 
     await expect(collect(results)).resolves.toEqual([
       { id: 30, name: 'c' },
       { id: 10, name: 'a' },
     ])
-    expect(rows).not.toHaveBeenCalled()
+    expect(results.rows).not.toHaveBeenCalled()
   })
 
   it('rejects partial rows when a cooperative batch source stops on abort', async () => {
@@ -153,19 +145,16 @@ describe('batch adapters', () => {
     const reason = new Error('batch collection aborted')
     /** @type {AsyncBatch} */
     const batch = {
-      schema: { fields: [schema.fields[0]] },
+      columnNames: [schema[0]],
       selection: { type: 'all', length: 1 },
       columns: [{
-        type: 'loaded',
-        vector: { type: 'constant', value: 1, length: 1 },
+        type: 'constant',
+        value: 1,
+        length: 1,
       }],
     }
-    const results = {
+    const results = batchResult({
       columns: ['id'],
-      async *rows() {},
-    }
-    registerBatchResults(results, {
-      schema: batch.schema,
       signal: controller.signal,
       async *batches() {
         yield batch

--- a/test/backend/batchAdapters.test.js
+++ b/test/backend/batchAdapters.test.js
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from 'vitest'
+import { selectedRowCount } from '../../src/backend/batch.js'
+import { collect } from '../../src/execute/utils.js'
+import { batchesToRows, rowsToBatches } from '../../src/backend/batchAdapters.js'
+import { registerBatchResults } from '../../src/execute/batchResults.js'
+
+/**
+ * @import { AsyncBatch, ColumnVector, ReadColumn, RelationSchema } from '../../src/internalTypes.js'
+ * @import { AsyncRow } from '../../src/types.js'
+ */
+
+/** @type {RelationSchema} */
+const schema = {
+  fields: [
+    { id: 0, name: 'id', dataType: { type: 'number' }, nullable: false },
+    { id: 1, name: 'name', dataType: { type: 'string' }, nullable: false },
+  ],
+}
+
+describe('batch adapters', () => {
+  it('materializes legacy rows into bounded aligned batches', async () => {
+    /** @type {AsyncRow[]} */
+    const rows = [
+      resolvedRow({ id: 1, name: 'a' }),
+      resolvedRow({ id: 2, name: 'b' }),
+      resolvedRow({ id: 3, name: 'c' }),
+    ]
+
+    const batches = []
+    for await (const batch of rowsToBatches(asyncValues(rows), schema, { batchRows: 2 })) {
+      batches.push(batch)
+    }
+
+    expect(batches.map(function summarize(batch) {
+      return {
+        rowCount: selectedRowCount(batch.selection),
+        ids: batch.columns[0].type === 'loaded'
+          && batch.columns[0].vector.type === 'values'
+          ? batch.columns[0].vector.values
+          : [],
+      }
+    })).toEqual([
+      { rowCount: 2, ids: [1, 2] },
+      { rowCount: 1, ids: [3] },
+    ])
+  })
+
+  it('keeps deferred columns lazy through the row adapter', async () => {
+    /** @type {ReadColumn} */
+    function readColumn() {
+      /** @type {ColumnVector} */
+      const vector = { type: 'values', values: [1, 2], length: 2 }
+      return Promise.resolve(vector)
+    }
+    const read = vi.fn(readColumn)
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema: { fields: [schema.fields[0]] },
+      selection: { type: 'all', length: 2 },
+      columns: [{ type: 'source', read }],
+    }
+
+    const iterator = batchesToRows(asyncValues([batch]))[Symbol.asyncIterator]()
+    const first = await iterator.next()
+    expect(read).not.toHaveBeenCalled()
+    if (first.done || !first.value) throw new Error('expected a row')
+    expect(await first.value.cells.id()).toBe(1)
+    expect(read).toHaveBeenCalledTimes(1)
+
+    const second = await iterator.next()
+    if (second.done || !second.value) throw new Error('expected a row')
+    expect(await second.value.cells.id()).toBe(2)
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('adapts loaded columns through the batch selection', async () => {
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: {
+        type: 'indices',
+        indices: new Uint32Array([2, 0]),
+        length: 3,
+      },
+      columns: [
+        {
+          type: 'loaded',
+          vector: { type: 'values', values: [10, 20, 30], length: 3 },
+        },
+        {
+          type: 'loaded',
+          vector: { type: 'values', values: ['a', 'b', 'c'], length: 3 },
+        },
+      ],
+    }
+
+    const rows = []
+    for await (const row of batchesToRows(asyncValues([batch]))) {
+      rows.push({
+        id: await row.cells.id(),
+        name: await row.cells.name(),
+      })
+    }
+
+    expect(rows).toEqual([
+      { id: 30, name: 'c' },
+      { id: 10, name: 'a' },
+    ])
+  })
+
+  it('collects native batches without consuming the row adapter', async () => {
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: {
+        type: 'indices',
+        indices: new Uint32Array([2, 0]),
+        length: 3,
+      },
+      columns: [
+        {
+          type: 'loaded',
+          vector: { type: 'values', values: [10, 20, 30], length: 3 },
+        },
+        {
+          type: 'loaded',
+          vector: { type: 'values', values: ['a', 'b', 'c'], length: 3 },
+        },
+      ],
+    }
+    const rows = vi.fn(function rows() {
+      throw new Error('row adapter should not be consumed')
+    })
+
+    const results = {
+      columns: ['id', 'name'],
+      rows,
+    }
+    registerBatchResults(results, {
+      schema,
+      async *batches() { yield batch },
+    })
+
+    await expect(collect(results)).resolves.toEqual([
+      { id: 30, name: 'c' },
+      { id: 10, name: 'a' },
+    ])
+    expect(rows).not.toHaveBeenCalled()
+  })
+
+  it('rejects partial rows when a cooperative batch source stops on abort', async () => {
+    const controller = new AbortController()
+    const reason = new Error('batch collection aborted')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema: { fields: [schema.fields[0]] },
+      selection: { type: 'all', length: 1 },
+      columns: [{
+        type: 'loaded',
+        vector: { type: 'constant', value: 1, length: 1 },
+      }],
+    }
+    const results = {
+      columns: ['id'],
+      async *rows() {},
+    }
+    registerBatchResults(results, {
+      schema: batch.schema,
+      signal: controller.signal,
+      async *batches() {
+        yield batch
+        controller.abort(reason)
+      },
+    })
+
+    await expect(collect(results)).rejects.toThrow('batch collection aborted')
+  })
+})
+
+/**
+ * @param {Record<string, import('../../src/types.js').SqlPrimitive>} values
+ * @returns {AsyncRow}
+ */
+function resolvedRow(values) {
+  return {
+    columns: Object.keys(values),
+    cells: Object.fromEntries(Object.entries(values).map(function cell([name, value]) {
+      return [name, function readCell() { return Promise.resolve(value) }]
+    })),
+    resolved: values,
+  }
+}
+
+/**
+ * @template T
+ * @param {T[]} values
+ * @yields {T}
+ */
+async function* asyncValues(values) {
+  yield* values
+}

--- a/test/execute/batchAggregate.test.js
+++ b/test/execute/batchAggregate.test.js
@@ -34,6 +34,19 @@ describe('private batch aggregate execution', () => {
       query: 'SELECT SUM(id * 10) FILTER (WHERE id > 2) AS total FROM data',
     }))).resolves.toEqual([{ total: 70 }])
   })
+
+  it('aggregates CASE, compound predicates, and NULLIF from private batches', async () => {
+    const source = columnSource([1, 2, 3, 4])
+
+    await expect(collect(executeSql({
+      tables: { data: source },
+      query: `SELECT
+        SUM(CASE WHEN id > 1 AND id < 4 THEN id ELSE 0 END) AS middle_total,
+        SUM(NULLIF(id, 2)) AS without_two
+        FROM data`,
+    }))).resolves.toEqual([{ middle_total: 5, without_two: 8 }])
+    expect(source.scan).not.toHaveBeenCalled()
+  })
 })
 
 /**

--- a/test/execute/batchAggregate.test.js
+++ b/test/execute/batchAggregate.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { collect, executeSql } from '../../src/index.js'
+
+/**
+ * @import { AsyncDataSource, ScanColumnResults } from '../../src/types.js'
+ */
+
+describe('private batch aggregate execution', () => {
+  it('groups computed values from the existing column scan API', async () => {
+    const source = columnSource([1, 2, 3, 4])
+
+    const results = executeSql({
+      tables: { data: source },
+      query: `SELECT id % 2 AS bucket,
+        COUNT(*) AS parts,
+        COUNT(DISTINCT id % 3) AS distinct_values,
+        SUM(id * 10) AS total,
+        COUNT(*) FILTER (WHERE id > 2) AS filtered
+        FROM data GROUP BY id % 2 ORDER BY bucket`,
+    })
+
+    expect(await collect(results)).toEqual([
+      { bucket: 0, parts: 2, distinct_values: 2, total: 60, filtered: 1 },
+      { bucket: 1, parts: 2, distinct_values: 2, total: 40, filtered: 1 },
+    ])
+    expect(source.scan).not.toHaveBeenCalled()
+  })
+
+  it('retains row semantics for filtered non-star aggregates', async () => {
+    const source = columnSource([1, 2, 3, 4])
+
+    await expect(collect(executeSql({
+      tables: { data: source },
+      query: 'SELECT SUM(id * 10) FILTER (WHERE id > 2) AS total FROM data',
+    }))).resolves.toEqual([{ total: 70 }])
+  })
+})
+
+/**
+ * @param {import('../../src/types.js').SqlPrimitive[]} values
+ * @returns {AsyncDataSource}
+ */
+function columnSource(values) {
+  return {
+    columns: ['id'],
+    scan: vi.fn(function scan() {
+      throw new Error('row scan should not be called')
+    }),
+    scanColumn() {
+      /** @type {ScanColumnResults} */
+      const results = {
+        appliedWhere: false,
+        appliedLimitOffset: false,
+        async *chunks() { yield values },
+      }
+      return results
+    },
+  }
+}

--- a/test/execute/batchAggregate.test.js
+++ b/test/execute/batchAggregate.test.js
@@ -47,6 +47,15 @@ describe('private batch aggregate execution', () => {
     }))).resolves.toEqual([{ middle_total: 5, without_two: 8 }])
     expect(source.scan).not.toHaveBeenCalled()
   })
+
+  it('preserves struct-field precedence over a bare column', async () => {
+    const source = columnSource([{ x: 2 }, { x: 3 }])
+
+    await expect(collect(executeSql({
+      tables: { data: source },
+      query: 'SELECT SUM(obj.x) AS total FROM (SELECT id AS obj, 99 AS x FROM data)',
+    }))).resolves.toEqual([{ total: 5 }])
+  })
 })
 
 /**

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -52,17 +52,49 @@ describe('native batch execution', () => {
     expect(rows).toEqual([4, 5])
   })
 
-  it('uses row execution when a source declines filter pushdown', async () => {
-    const source = columnSource(function chunks() { return [[1, 2, 3, 4]] }, false)
+  it('turns a residual predicate into a private batch selection', async () => {
+    const source = columnSource(function chunks() { return [[null, 2, 3, 4]] }, false)
     const results = executeSql({
       tables: { data: source },
       query: 'SELECT id FROM data WHERE id > 2',
     })
 
-    expect(batchResultsFor(results)).toBeUndefined()
+    expect(Object.keys(results)).toEqual(['columns', 'numRows', 'maxRows', 'rows'])
     expect(Object.hasOwn(results, 'batches')).toBe(false)
     expect(Object.hasOwn(results, 'schema')).toBe(false)
+    const batchResults = batchResultsFor(results)
+    if (!batchResults) throw new Error('expected internal batches')
+    const iterator = batchResults.batches()[Symbol.asyncIterator]()
+    const first = await iterator.next()
+    if (first.done) throw new Error('expected a batch')
+    expect(first.value.selection).toEqual({
+      type: 'bitmap',
+      values: new Uint8Array([0, 0, 1, 1]),
+      length: 4,
+    })
     expect(await collect(results)).toEqual([{ id: 3 }, { id: 4 }])
+  })
+
+  it('applies a residual predicate before limit and offset', async () => {
+    const source = columnSource(function chunks() { return [[1, 2, 3, 4], [5, 6, 7, 8]] }, false)
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id FROM data WHERE id % 2 = 0 LIMIT 2 OFFSET 1',
+    })
+
+    expect(batchResultsFor(results)).toBeDefined()
+    expect(await collect(results)).toEqual([{ id: 4 }, { id: 6 }])
+  })
+
+  it('retains row filtering for an unsupported batch predicate', async () => {
+    const source = columnSource(function chunks() { return [[null, 2, 3]] }, false)
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id FROM data WHERE COALESCE(id, 0) > 2',
+    })
+
+    expect(batchResultsFor(results)).toBeUndefined()
+    expect(await collect(results)).toEqual([{ id: 3 }])
   })
 })
 

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -87,14 +87,14 @@ describe('native batch execution', () => {
     expect(results.rows).not.toHaveBeenCalled()
   })
 
-  it('retains row projection for an unsupported batch expression', async () => {
+  it('executes CASE projections through private batches', async () => {
     const source = columnSource(function chunks() { return [[null, 2]] })
     const results = executeSql({
       tables: { data: source },
       query: 'SELECT CASE WHEN id IS NULL THEN 0 ELSE id END AS value FROM data',
     })
 
-    expect(batchResultsFor(results)).toBeUndefined()
+    expect(batchResultsFor(results)).toBeDefined()
     expect(await collect(results)).toEqual([{ value: 0 }, { value: 2 }])
   })
 
@@ -132,14 +132,25 @@ describe('native batch execution', () => {
     expect(await collect(results)).toEqual([{ id: 4 }, { id: 6 }])
   })
 
-  it('retains row filtering for an unsupported batch predicate', async () => {
+  it('executes compound logical predicates through private batches', async () => {
+    const source = columnSource(function chunks() { return [[1, 2, 3, 4, 5]] }, false)
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id FROM data WHERE (id > 1 AND id < 4) OR id = 5',
+    })
+
+    expect(batchResultsFor(results)).toBeDefined()
+    expect(await collect(results)).toEqual([{ id: 2 }, { id: 3 }, { id: 5 }])
+  })
+
+  it('executes CASE predicates through private batches', async () => {
     const source = columnSource(function chunks() { return [[null, 2, 3]] }, false)
     const results = executeSql({
       tables: { data: source },
       query: 'SELECT id FROM data WHERE CASE WHEN id IS NULL THEN 0 ELSE id END > 2',
     })
 
-    expect(batchResultsFor(results)).toBeUndefined()
+    expect(batchResultsFor(results)).toBeDefined()
     expect(await collect(results)).toEqual([{ id: 3 }])
   })
 
@@ -156,14 +167,14 @@ describe('native batch execution', () => {
     expect(await collect(results)).toEqual([{ value: 9 }, { value: 12 }])
   })
 
-  it('uses rows for an unsupported predicate over a batched subquery', async () => {
+  it('keeps CASE predicates over subqueries in private batches', async () => {
     const source = columnSource(function chunks() { return [[null, 2, 3]] })
     const results = executeSql({
       tables: { data: source },
       query: 'SELECT value FROM (SELECT id AS value FROM data) WHERE CASE WHEN value IS NULL THEN 0 ELSE value END > 2',
     })
 
-    expect(batchResultsFor(results)).toBeUndefined()
+    expect(batchResultsFor(results)).toBeDefined()
     expect(await collect(results)).toEqual([{ value: 3 }])
   })
 

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -52,6 +52,52 @@ describe('native batch execution', () => {
     expect(rows).toEqual([4, 5])
   })
 
+  it('keeps computed projection private and lazy at column granularity', async () => {
+    const source = columnSource(function chunks() { return [['a', 'abcd', null]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT LENGTH(id) + 1 AS size FROM data',
+    })
+
+    expect(Object.keys(results)).toEqual(['columns', 'numRows', 'maxRows', 'rows'])
+    const batchResults = batchResultsFor(results)
+    if (!batchResults) throw new Error('expected internal batches')
+    const iterator = batchResults.batches()[Symbol.asyncIterator]()
+    const first = await iterator.next()
+    if (first.done) throw new Error('expected a batch')
+    const [column] = first.value.columns
+    expect(column.type).toBe('computed')
+    if (column.type !== 'computed') throw new Error('expected a computed column')
+    expect(column.dependencies).toEqual([0])
+
+    expect(await collect(results)).toEqual([{ size: 2 }, { size: 5 }, { size: null }])
+  })
+
+  it('collects computed projections without constructing compatibility rows', async () => {
+    const source = columnSource(function chunks() { return [['one', 'three']] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT UPPER(id) AS value FROM data',
+    })
+
+    results.rows = vi.fn(function rows() {
+      throw new Error('row adapter should not be called')
+    })
+    expect(await collect(results)).toEqual([{ value: 'ONE' }, { value: 'THREE' }])
+    expect(results.rows).not.toHaveBeenCalled()
+  })
+
+  it('retains row projection for an unsupported batch expression', async () => {
+    const source = columnSource(function chunks() { return [[null, 2]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT COALESCE(id, 0) AS value FROM data',
+    })
+
+    expect(batchResultsFor(results)).toBeUndefined()
+    expect(await collect(results)).toEqual([{ value: 0 }, { value: 2 }])
+  })
+
   it('turns a residual predicate into a private batch selection', async () => {
     const source = columnSource(function chunks() { return [[null, 2, 3, 4]] }, false)
     const results = executeSql({

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -91,7 +91,7 @@ describe('native batch execution', () => {
     const source = columnSource(function chunks() { return [[null, 2]] })
     const results = executeSql({
       tables: { data: source },
-      query: 'SELECT COALESCE(id, 0) AS value FROM data',
+      query: 'SELECT CASE WHEN id IS NULL THEN 0 ELSE id END AS value FROM data',
     })
 
     expect(batchResultsFor(results)).toBeUndefined()
@@ -136,7 +136,7 @@ describe('native batch execution', () => {
     const source = columnSource(function chunks() { return [[null, 2, 3]] }, false)
     const results = executeSql({
       tables: { data: source },
-      query: 'SELECT id FROM data WHERE COALESCE(id, 0) > 2',
+      query: 'SELECT id FROM data WHERE CASE WHEN id IS NULL THEN 0 ELSE id END > 2',
     })
 
     expect(batchResultsFor(results)).toBeUndefined()
@@ -160,7 +160,7 @@ describe('native batch execution', () => {
     const source = columnSource(function chunks() { return [[null, 2, 3]] })
     const results = executeSql({
       tables: { data: source },
-      query: 'SELECT value FROM (SELECT id AS value FROM data) WHERE COALESCE(value, 0) > 2',
+      query: 'SELECT value FROM (SELECT id AS value FROM data) WHERE CASE WHEN value IS NULL THEN 0 ELSE value END > 2',
     })
 
     expect(batchResultsFor(results)).toBeUndefined()

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -166,6 +166,19 @@ describe('native batch execution', () => {
     expect(batchResultsFor(results)).toBeUndefined()
     expect(await collect(results)).toEqual([{ value: 3 }])
   })
+
+  it('executes distinct over private computed batches', async () => {
+    const source = columnSource(function chunks() { return [[1, 2, 3], [4, 5]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT DISTINCT id % 2 AS value FROM data',
+    })
+
+    expect(Object.hasOwn(results, 'batches')).toBe(false)
+    expect(Object.hasOwn(results, 'schema')).toBe(false)
+    expect(batchResultsFor(results)).toBeDefined()
+    expect(await collect(results)).toEqual([{ value: 1 }, { value: 0 }])
+  })
 })
 
 /**

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { collect, executeSql } from '../../src/index.js'
+import { batchResultsFor } from '../../src/execute/batchResults.js'
+
+/**
+ * @import { AsyncDataSource, ScanColumnResults } from '../../src/types.js'
+ */
+
+describe('native batch execution', () => {
+  it('preserves a typed scan chunk through projection', async () => {
+    const values = new Int32Array([10, 20, 30])
+    const source = columnSource(function chunks() { return [values] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id AS value FROM data',
+    })
+
+    expect(Object.keys(results)).toEqual(['columns', 'numRows', 'maxRows', 'rows'])
+    const batchResults = batchResultsFor(results)
+    if (!batchResults) throw new Error('expected internal batches')
+    const iterator = batchResults.batches()[Symbol.asyncIterator]()
+    const first = await iterator.next()
+    if (first.done) throw new Error('expected a batch')
+    const column = first.value.columns[0]
+    expect(column.type).toBe('loaded')
+    if (column.type !== 'loaded') throw new Error('expected a loaded column')
+    expect(column.vector.type).toBe('typed')
+    if (column.vector.type !== 'typed') throw new Error('expected a typed vector')
+    expect(column.vector.values).toBe(values)
+    expect(first.value.schema.fields[0].name).toBe('value')
+  })
+
+  it('applies limit and offset as a zero-copy selection across chunks', async () => {
+    const source = columnSource(function chunks() {
+      return [[1, 2], [3, 4, 5], [6]]
+    }, false)
+
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id FROM data LIMIT 3 OFFSET 2',
+    })
+
+    expect(await collect(results)).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }])
+  })
+
+  it('keeps rows as a compatibility view over native batches', async () => {
+    const source = columnSource(function chunks() { return [[4, 5]] })
+    const results = executeSql({ tables: { data: source }, query: 'SELECT id FROM data' })
+
+    const rows = []
+    for await (const row of results.rows()) rows.push(await row.cells.id())
+    expect(rows).toEqual([4, 5])
+  })
+
+  it('uses row execution when a source declines filter pushdown', async () => {
+    const source = columnSource(function chunks() { return [[1, 2, 3, 4]] }, false)
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id FROM data WHERE id > 2',
+    })
+
+    expect(batchResultsFor(results)).toBeUndefined()
+    expect(Object.hasOwn(results, 'batches')).toBe(false)
+    expect(Object.hasOwn(results, 'schema')).toBe(false)
+    expect(await collect(results)).toEqual([{ id: 3 }, { id: 4 }])
+  })
+})
+
+/**
+ * @param {() => ArrayLike<import('../../src/types.js').SqlPrimitive>[]} readChunks
+ * @param {boolean} [appliedLimitOffset]
+ * @returns {AsyncDataSource}
+ */
+function columnSource(readChunks, appliedLimitOffset = true) {
+  return {
+    columns: ['id'],
+    scan: vi.fn(function scan() {
+      throw new Error('row scan should not be called')
+    }),
+    scanColumn() {
+      /** @type {ScanColumnResults} */
+      const result = {
+        appliedWhere: false,
+        appliedLimitOffset,
+        async *chunks() {
+          yield* readChunks()
+        },
+      }
+      return result
+    },
+  }
+}

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -22,12 +22,10 @@ describe('native batch execution', () => {
     const first = await iterator.next()
     if (first.done) throw new Error('expected a batch')
     const column = first.value.columns[0]
-    expect(column.type).toBe('loaded')
-    if (column.type !== 'loaded') throw new Error('expected a loaded column')
-    expect(column.vector.type).toBe('typed')
-    if (column.vector.type !== 'typed') throw new Error('expected a typed vector')
-    expect(column.vector.values).toBe(values)
-    expect(first.value.schema.fields[0].name).toBe('value')
+    expect(column.type).toBe('typed')
+    if (column.type !== 'typed') throw new Error('expected a typed vector')
+    expect(column.values).toBe(values)
+    expect(first.value.columnNames[0]).toBe('value')
   })
 
   it('applies limit and offset as a zero-copy selection across chunks', async () => {
@@ -68,7 +66,7 @@ describe('native batch execution', () => {
     const [column] = first.value.columns
     expect(column.type).toBe('computed')
     if (column.type !== 'computed') throw new Error('expected a computed column')
-    expect(column.dependencies).toEqual([0])
+    expect(column.expression).toBeDefined()
 
     expect(await collect(results)).toEqual([{ size: 2 }, { size: 5 }, { size: null }])
   })
@@ -114,8 +112,8 @@ describe('native batch execution', () => {
     const first = await iterator.next()
     if (first.done) throw new Error('expected a batch')
     expect(first.value.selection).toEqual({
-      type: 'bitmap',
-      values: new Uint8Array([0, 0, 1, 1]),
+      type: 'indices',
+      indices: new Uint32Array([2, 3]),
       length: 4,
     })
     expect(await collect(results)).toEqual([{ id: 3 }, { id: 4 }])

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -190,6 +190,27 @@ describe('native batch execution', () => {
     expect(batchResultsFor(results)).toBeDefined()
     expect(await collect(results)).toEqual([{ value: 1 }, { value: 0 }])
   })
+
+  it('falls back to row projection for duplicate aliases', async () => {
+    const source = columnSource(function chunks() { return [[1, 2]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT DISTINCT x FROM (SELECT id AS x, 1 AS x FROM data)',
+    })
+
+    expect(batchResultsFor(results)).toBeDefined()
+    expect(await collect(results)).toEqual([{ x: 1 }])
+  })
+
+  it('preserves projected row positions through a later offset', async () => {
+    const source = columnSource(function chunks() { return [[1, 2, 3, { value: 4 }]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT value FROM (SELECT CAST(id AS INTEGER) AS value FROM data) OFFSET 3',
+    })
+
+    await expect(collect(results)).rejects.toThrow('Cannot CAST object to INTEGER (row 4)')
+  })
 })
 
 /**

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -142,6 +142,30 @@ describe('native batch execution', () => {
     expect(batchResultsFor(results)).toBeUndefined()
     expect(await collect(results)).toEqual([{ id: 3 }])
   })
+
+  it('filters a computed subquery through private batches', async () => {
+    const source = columnSource(function chunks() { return [[1, 2, 3, 4]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT value FROM (SELECT id * 3 AS value FROM data) WHERE value > 6',
+    })
+
+    expect(Object.hasOwn(results, 'batches')).toBe(false)
+    expect(Object.hasOwn(results, 'schema')).toBe(false)
+    expect(batchResultsFor(results)).toBeDefined()
+    expect(await collect(results)).toEqual([{ value: 9 }, { value: 12 }])
+  })
+
+  it('uses rows for an unsupported predicate over a batched subquery', async () => {
+    const source = columnSource(function chunks() { return [[null, 2, 3]] })
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT value FROM (SELECT id AS value FROM data) WHERE COALESCE(value, 0) > 2',
+    })
+
+    expect(batchResultsFor(results)).toBeUndefined()
+    expect(await collect(results)).toEqual([{ value: 3 }])
+  })
 })
 
 /**

--- a/test/execute/batches.test.js
+++ b/test/execute/batches.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readBatchColumn, selectedRowCount } from '../../src/backend/batch.js'
+import { filterBatches } from '../../src/execute/batches.js'
+import { compileBatchExpression } from '../../src/expression/batch.js'
+import { parseSql } from '../../src/parse/parse.js'
+
+/**
+ * @import { AsyncBatch, ReadColumn, RelationSchema } from '../../src/internalTypes.js'
+ * @import { ExprNode } from '../../src/types.js'
+ */
+
+/** @type {RelationSchema} */
+const schema = {
+  fields: [
+    { id: 0, name: 'keep', dataType: { type: 'boolean' }, nullable: false },
+    { id: 1, name: 'payload', dataType: { type: 'string' }, nullable: false },
+  ],
+}
+
+describe('batch operators', () => {
+  it('filters on predicate columns without reading deferred payloads', async () => {
+    /** @type {ReadColumn} */
+    function readPayload({ selection }) {
+      return { type: 'constant', value: 'large text', length: selectedRowCount(selection) }
+    }
+    const read = vi.fn(readPayload)
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 4 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [true, false, true, false], length: 4 } },
+        { type: 'source', read },
+      ],
+    }
+    const expression = compileBatchExpression({ expression: parseExpression('keep'), schema })
+    if (!expression) throw new Error('expected expression to compile')
+
+    const filtered = []
+    for await (const result of filterBatches(asyncValues([batch]), expression)) filtered.push(result)
+
+    expect(read).not.toHaveBeenCalled()
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].selection).toEqual({
+      type: 'bitmap',
+      values: new Uint8Array([1, 0, 1, 0]),
+      length: 4,
+    })
+    expect(readBatchColumn({ batch: filtered[0], columnIndex: 1 })).toEqual({
+      type: 'constant',
+      value: 'large text',
+      length: 2,
+    })
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * @param {string} sql
+ * @returns {ExprNode}
+ */
+function parseExpression(sql) {
+  const statement = parseSql({ query: `SELECT ${sql}` })
+  if (statement.type !== 'select') throw new Error('expected select statement')
+  const [column] = statement.columns
+  if (column.type !== 'derived') throw new Error('expected derived column')
+  return column.expr
+}
+
+/**
+ * @template T
+ * @param {T[]} values
+ * @yields {T}
+ */
+async function* asyncValues(values) {
+  yield* values
+}

--- a/test/execute/batches.test.js
+++ b/test/execute/batches.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { readBatchColumn, selectedRowCount } from '../../src/backend/batch.js'
-import { filterBatches } from '../../src/execute/batches.js'
+import { distinctBatches, filterBatches } from '../../src/execute/batches.js'
 import { compileBatchExpression } from '../../src/expression/batch.js'
 import { parseSql } from '../../src/parse/parse.js'
 
@@ -53,6 +53,28 @@ describe('batch operators', () => {
     })
     expect(read).toHaveBeenCalledTimes(1)
   })
+
+  it('deduplicates across batches with zero-copy selections', async () => {
+    const first = valueBatch(['a', 'b', 'a'])
+    const second = valueBatch(['b', 'c'])
+
+    const distinct = []
+    for await (const result of distinctBatches(asyncValues([first, second]))) distinct.push(result)
+
+    expect(distinct).toHaveLength(2)
+    expect(distinct[0].columns[0]).toBe(first.columns[0])
+    expect(distinct[0].selection).toEqual({
+      type: 'indices',
+      indices: new Uint32Array([0, 1]),
+      length: 3,
+    })
+    expect(distinct[1].columns[0]).toBe(second.columns[0])
+    expect(distinct[1].selection).toEqual({
+      type: 'indices',
+      indices: new Uint32Array([1]),
+      length: 2,
+    })
+  })
 })
 
 /**
@@ -74,4 +96,25 @@ function parseExpression(sql) {
  */
 async function* asyncValues(values) {
   yield* values
+}
+
+/**
+ * @param {import('../../src/types.js').SqlPrimitive[]} values
+ * @returns {AsyncBatch}
+ */
+function valueBatch(values) {
+  /** @type {RelationSchema} */
+  const valueSchema = {
+    fields: [
+      { id: 0, name: 'value', dataType: { type: 'unknown' }, nullable: true },
+    ],
+  }
+  return {
+    schema: valueSchema,
+    selection: { type: 'all', length: values.length },
+    columns: [{
+      type: 'loaded',
+      vector: { type: 'values', values, length: values.length },
+    }],
+  }
 }

--- a/test/execute/batches.test.js
+++ b/test/execute/batches.test.js
@@ -5,17 +5,11 @@ import { compileBatchExpression } from '../../src/expression/batch.js'
 import { parseSql } from '../../src/parse/parse.js'
 
 /**
- * @import { AsyncBatch, ReadColumn, RelationSchema } from '../../src/internalTypes.js'
+ * @import { AsyncBatch, ReadColumn } from '../../src/internalTypes.js'
  * @import { ExprNode } from '../../src/types.js'
  */
 
-/** @type {RelationSchema} */
-const schema = {
-  fields: [
-    { id: 0, name: 'keep', dataType: { type: 'boolean' }, nullable: false },
-    { id: 1, name: 'payload', dataType: { type: 'string' }, nullable: false },
-  ],
-}
+const schema = ['keep', 'payload']
 
 describe('batch operators', () => {
   it('filters on predicate columns without reading deferred payloads', async () => {
@@ -26,14 +20,14 @@ describe('batch operators', () => {
     const read = vi.fn(readPayload)
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 4 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [true, false, true, false], length: 4 } },
+        { type: 'values', values: [true, false, true, false], length: 4 },
         { type: 'source', read },
       ],
     }
-    const expression = compileBatchExpression({ expression: parseExpression('keep'), schema })
+    const expression = compileBatchExpression(parseExpression('keep'), schema)
     if (!expression) throw new Error('expected expression to compile')
 
     const filtered = []
@@ -42,8 +36,8 @@ describe('batch operators', () => {
     expect(read).not.toHaveBeenCalled()
     expect(filtered).toHaveLength(1)
     expect(filtered[0].selection).toEqual({
-      type: 'bitmap',
-      values: new Uint8Array([1, 0, 1, 0]),
+      type: 'indices',
+      indices: new Uint32Array([0, 2]),
       length: 4,
     })
     expect(readBatchColumn({ batch: filtered[0], columnIndex: 1 })).toEqual({
@@ -59,7 +53,6 @@ describe('batch operators', () => {
     const evaluations = []
     /** @type {import('../../src/internalTypes.js').CompiledBatchExpression} */
     const expression = {
-      dependencies: [],
       evaluate({ selection, rowOffset = 0 }) {
         const length = selectedRowCount(selection)
         evaluations.push({ length, rowOffset })
@@ -86,7 +79,6 @@ describe('batch operators', () => {
     const evaluations = []
     /** @type {import('../../src/internalTypes.js').CompiledBatchExpression} */
     const expression = {
-      dependencies: [],
       evaluate({ selection, rowOffset = 0 }) {
         const length = selectedRowCount(selection)
         evaluations.push({ length, rowOffset })
@@ -165,18 +157,13 @@ async function* asyncValues(values) {
  * @returns {AsyncBatch}
  */
 function valueBatch(values) {
-  /** @type {RelationSchema} */
-  const valueSchema = {
-    fields: [
-      { id: 0, name: 'value', dataType: { type: 'unknown' }, nullable: true },
-    ],
-  }
   return {
-    schema: valueSchema,
+    columnNames: ['value'],
     selection: { type: 'all', length: values.length },
     columns: [{
-      type: 'loaded',
-      vector: { type: 'values', values, length: values.length },
+      type: 'values',
+      values,
+      length: values.length,
     }],
   }
 }

--- a/test/execute/batches.test.js
+++ b/test/execute/batches.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { readBatchColumn, selectedRowCount } from '../../src/backend/batch.js'
-import { distinctBatches, filterBatches } from '../../src/execute/batches.js'
+import { distinctBatches, filterBatches, limitBatches } from '../../src/execute/batches.js'
 import { compileBatchExpression } from '../../src/expression/batch.js'
 import { parseSql } from '../../src/parse/parse.js'
 
@@ -52,6 +52,68 @@ describe('batch operators', () => {
       length: 2,
     })
     expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds predicate work when a downstream limit needs few matches', async () => {
+    /** @type {{ length: number, rowOffset: number }[]} */
+    const evaluations = []
+    /** @type {import('../../src/internalTypes.js').CompiledBatchExpression} */
+    const expression = {
+      dependencies: [],
+      evaluate({ selection, rowOffset = 0 }) {
+        const length = selectedRowCount(selection)
+        evaluations.push({ length, rowOffset })
+        return { type: 'constant', value: true, length }
+      },
+    }
+    const batches = filterBatches(asyncValues([valueBatch(new Array(1_000).fill(true))]), expression, undefined, 1)
+    const limited = []
+
+    for await (const result of limitBatches(batches, 1)) limited.push(result)
+
+    expect(evaluations).toEqual([{ length: 256, rowOffset: 0 }])
+    expect(limited).toHaveLength(1)
+    expect(limited[0].selection).toEqual({
+      type: 'range',
+      start: 0,
+      end: 1,
+      length: 1_000,
+    })
+  })
+
+  it('grows predicate windows while preserving row offsets for late matches', async () => {
+    /** @type {{ length: number, rowOffset: number }[]} */
+    const evaluations = []
+    /** @type {import('../../src/internalTypes.js').CompiledBatchExpression} */
+    const expression = {
+      dependencies: [],
+      evaluate({ selection, rowOffset = 0 }) {
+        const length = selectedRowCount(selection)
+        evaluations.push({ length, rowOffset })
+        const values = new Array(length).fill(false)
+        if (rowOffset <= 700 && rowOffset + length > 700) values[700 - rowOffset] = true
+        return { type: 'values', values, length }
+      },
+    }
+    const batches = filterBatches(asyncValues([
+      valueBatch(new Array(100).fill(true)),
+      valueBatch(new Array(1_000).fill(true)),
+    ]), expression, undefined, 1)
+    const limited = []
+
+    for await (const result of limitBatches(batches, 1)) limited.push(result)
+
+    expect(evaluations).toEqual([
+      { length: 100, rowOffset: 0 },
+      { length: 512, rowOffset: 100 },
+      { length: 488, rowOffset: 612 },
+    ])
+    expect(limited).toHaveLength(1)
+    expect(limited[0].selection).toEqual({
+      type: 'indices',
+      indices: new Uint32Array([600]),
+      length: 1_000,
+    })
   })
 
   it('deduplicates across batches with zero-copy selections', async () => {

--- a/test/execute/scan.test.js
+++ b/test/execute/scan.test.js
@@ -235,6 +235,42 @@ describe('scanColumn fast path', () => {
     expect(await collect(results)).toEqual([{ id: 1 }, { id: 2 }])
     expect(chunksCalled).toBe(true)
   })
+
+  it('should bound residual scanColumn filtering for a small limit and offset', async () => {
+    let valueReads = 0
+    const values = new Proxy(Array.from({ length: 1_000 }, function value(_unused, index) {
+      return index
+    }), {
+      get(target, property, receiver) {
+        if (typeof property === 'string' && /^\d+$/.test(property)) valueReads++
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    /** @type {AsyncDataSource} */
+    const source = {
+      columns: ['id'],
+      scan() {
+        throw new Error('scan should not be called')
+      },
+      scanColumn() {
+        return {
+          appliedWhere: false,
+          appliedLimitOffset: false,
+          async *chunks() {
+            yield values
+          },
+        }
+      },
+    }
+
+    const results = executeSql({
+      tables: { data: source },
+      query: 'SELECT id FROM data WHERE id >= 0 LIMIT 1 OFFSET 300',
+    })
+
+    expect(await collect(results)).toEqual([{ id: 300 }])
+    expect(valueReads).toBe(302)
+  })
 })
 
 

--- a/test/expression/batch.test.js
+++ b/test/expression/batch.test.js
@@ -76,20 +76,74 @@ describe('batch expressions', () => {
     expect(read).toHaveBeenCalledTimes(1)
   })
 
-  it('preserves scalar short-circuit behavior', () => {
-    const compiled = compile('FALSE AND LENGTH(n) > 0')
+  it('declines expressions whose short-circuited branches read columns', () => {
+    expect(compile('FALSE AND LENGTH(n) > 0')).toBeUndefined()
+    expect(compile('TRUE OR LENGTH(n) > 0')).toBeUndefined()
+    expect(compile('COALESCE(1, n)')).toBeUndefined()
+  })
+
+  it('compiles production JSON token expressions', () => {
+    const compiled = compile('COALESCE(CAST(JSON_EXTRACT(text, \'$.usage.input_tokens\') AS BIGINT), 0)')
+    if (!compiled) throw new Error('expected expression to compile')
+    const batch = loadedBatch([1, 2, 3], [
+      { usage: { input_tokens: 42 } },
+      { usage: {} },
+      null,
+    ])
+
+    expect(compiled.evaluate({ batch, selection: batch.selection })).toEqual({
+      type: 'values',
+      values: [42n, 0, 0],
+      length: 3,
+    })
+  })
+
+  it('resolves qualified identifiers against a bare scan schema', () => {
+    const compiled = compile('data.n + 1')
     if (!compiled) throw new Error('expected expression to compile')
     const batch = loadedBatch([1, 2], ['a', 'b'])
 
     expect(compiled.evaluate({ batch, selection: batch.selection })).toEqual({
       type: 'values',
-      values: [false, false],
+      values: [2, 3],
       length: 2,
     })
   })
 
+  it('uses a stream row offset in execution errors', () => {
+    const compiled = compile('LENGTH(n)')
+    if (!compiled) throw new Error('expected expression to compile')
+    const batch = loadedBatch([1], ['unused'])
+
+    expect(() => compiled.evaluate({
+      batch,
+      selection: batch.selection,
+      rowOffset: 2,
+    })).toThrow('LENGTH(string): expected string or array, got number. Use CAST to convert to a string first. (row 3)')
+  })
+
+  it('yields during large cancellable kernel evaluation', async () => {
+    const compiled = compile('n + 1')
+    if (!compiled) throw new Error('expected expression to compile')
+    const values = Array.from({ length: 50_000 }, function value(_item, index) { return index })
+    const batch = loadedBatch(values, values)
+    const controller = new AbortController()
+    const reason = new Error('timeout')
+    const timer = setTimeout(function abort() { controller.abort(reason) }, 0)
+
+    try {
+      await expect(compiled.evaluate({
+        batch,
+        selection: batch.selection,
+        signal: controller.signal,
+      })).rejects.toBe(reason)
+    } finally {
+      clearTimeout(timer)
+    }
+  })
+
   it('declines unsupported expressions and missing identifiers', () => {
-    expect(compileBatchExpression({ expression: expression('COALESCE(n, 0)'), schema })).toBeUndefined()
+    expect(compileBatchExpression({ expression: expression('CASE WHEN n > 0 THEN n END'), schema })).toBeUndefined()
     expect(compileBatchExpression({ expression: expression('missing + 1'), schema })).toBeUndefined()
   })
 })

--- a/test/expression/batch.test.js
+++ b/test/expression/batch.test.js
@@ -76,10 +76,150 @@ describe('batch expressions', () => {
     expect(read).toHaveBeenCalledTimes(1)
   })
 
-  it('declines expressions whose short-circuited branches read columns', () => {
-    expect(compile('FALSE AND LENGTH(n) > 0')).toBeUndefined()
-    expect(compile('TRUE OR LENGTH(n) > 0')).toBeUndefined()
-    expect(compile('COALESCE(1, n)')).toBeUndefined()
+  it('reads logical right-side columns only for undecided rows', async () => {
+    /** @type {ReadColumn} */
+    function readText({ selection }) {
+      expect(selection).toEqual({
+        type: 'indices',
+        indices: new Uint32Array([0, 2]),
+        length: 3,
+      })
+      return { type: 'values', values: ['a', ''], length: 2 }
+    }
+    const read = vi.fn(readText)
+    const compiled = compile('n < 0 AND LENGTH(text) > 0')
+    if (!compiled) throw new Error('expected expression to compile')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 3 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [-1, 1, -2], length: 3 } },
+        { type: 'source', read },
+      ],
+    }
+
+    await expect(compiled.evaluate({ batch, selection: batch.selection })).resolves.toEqual({
+      type: 'values',
+      values: [true, false, false],
+      length: 3,
+    })
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads later COALESCE arguments only for null rows', async () => {
+    /** @type {ReadColumn} */
+    function readText({ selection }) {
+      expect(selection).toEqual({
+        type: 'indices',
+        indices: new Uint32Array([1, 2]),
+        length: 3,
+      })
+      return { type: 'values', values: ['fallback', null], length: 2 }
+    }
+    const read = vi.fn(readText)
+    const compiled = compile('COALESCE(n, text)')
+    if (!compiled) throw new Error('expected expression to compile')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 3 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [1, null, null], length: 3 } },
+        { type: 'source', read },
+      ],
+    }
+
+    await expect(compiled.evaluate({ batch, selection: batch.selection })).resolves.toEqual({
+      type: 'values',
+      values: [1, 'fallback', null],
+      length: 3,
+    })
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('evaluates searched CASE branches over matching row selections', async () => {
+    /** @type {ReadColumn} */
+    function readText({ selection }) {
+      expect(selection).toEqual({
+        type: 'indices',
+        indices: new Uint32Array([0]),
+        length: 3,
+      })
+      return { type: 'values', values: ['yes'], length: 1 }
+    }
+    const read = vi.fn(readText)
+    const compiled = compile(`CASE
+      WHEN n > 0 THEN UPPER(text)
+      WHEN n = 0 THEN 'zero'
+      ELSE NULL
+    END`)
+    if (!compiled) throw new Error('expected expression to compile')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 3 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [1, 0, -1], length: 3 } },
+        { type: 'source', read },
+      ],
+    }
+
+    await expect(compiled.evaluate({ batch, selection: batch.selection })).resolves.toEqual({
+      type: 'values',
+      values: ['YES', 'zero', null],
+      length: 3,
+    })
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('composes CASE branch selections and preserves stream row numbers', async () => {
+    /** @type {ReadColumn} */
+    function readText({ selection }) {
+      expect(selection).toEqual({
+        type: 'indices',
+        indices: new Uint32Array([3]),
+        length: 4,
+      })
+      return { type: 'values', values: [3], length: 1 }
+    }
+    const read = vi.fn(readText)
+    const compiled = compile('CASE WHEN n > 0 THEN LENGTH(text) ELSE 0 END')
+    if (!compiled) throw new Error('expected expression to compile')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'indices', indices: new Uint32Array([1, 3]), length: 4 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [0, -1, 0, 1], length: 4 } },
+        { type: 'source', read },
+      ],
+    }
+
+    await expect(compiled.evaluate({
+      batch,
+      selection: batch.selection,
+      rowOffset: 10,
+    })).rejects.toThrow(
+      'LENGTH(string): expected string or array, got number. Use CAST to convert to a string first. (row 12)'
+    )
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('compiles simple CASE and NULLIF combinations', async () => {
+    const compiled = compile(`CASE n
+      WHEN 1 THEN COALESCE(NULLIF(text, ''), 'empty')
+      WHEN 2 THEN NULLIF(text, 'same')
+      ELSE 'other'
+    END`)
+    if (!compiled) throw new Error('expected expression to compile')
+    const batch = loadedBatch([1, 2, 3], ['', 'same', 'value'])
+
+    await expect(compiled.evaluate({ batch, selection: batch.selection })).resolves.toEqual({
+      type: 'values',
+      values: ['empty', null, 'other'],
+      length: 3,
+    })
   })
 
   it('compiles production JSON token expressions', () => {
@@ -143,7 +283,7 @@ describe('batch expressions', () => {
   })
 
   it('declines unsupported expressions and missing identifiers', () => {
-    expect(compileBatchExpression({ expression: expression('CASE WHEN n > 0 THEN n END'), schema })).toBeUndefined()
+    expect(compileBatchExpression({ expression: expression('CASE WHEN n > 0 THEN ABS(n) END'), schema })).toBeUndefined()
     expect(compileBatchExpression({ expression: expression('missing + 1'), schema })).toBeUndefined()
   })
 })

--- a/test/expression/batch.test.js
+++ b/test/expression/batch.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest'
+import { compileBatchExpression } from '../../src/expression/batch.js'
+import { parseSql } from '../../src/parse/parse.js'
+
+/**
+ * @import { AsyncBatch, ReadColumn, RelationSchema, RowSelection } from '../../src/internalTypes.js'
+ * @import { ExprNode } from '../../src/types.js'
+ */
+
+/** @type {RelationSchema} */
+const schema = {
+  fields: [
+    { id: 0, name: 'n', dataType: { type: 'number' }, nullable: true },
+    { id: 1, name: 'text', dataType: { type: 'string' }, nullable: true },
+  ],
+}
+
+describe('batch expressions', () => {
+  it('resolves each dependency once for a synchronous vector kernel', () => {
+    const compiled = compile('LENGTH(text) + n')
+    expect(compiled?.dependencies).toEqual([1, 0])
+    if (!compiled) throw new Error('expected expression to compile')
+    const batch = loadedBatch([2, null, 4], ['abc', 'x', null])
+
+    const result = compiled.evaluate({ batch, selection: batch.selection })
+
+    expect(result).toEqual({
+      type: 'values',
+      values: [5, null, null],
+      length: 3,
+    })
+    expect(result).not.toBeInstanceOf(Promise)
+  })
+
+  it('evaluates only selected rows', () => {
+    const compiled = compile('UPPER(text)')
+    if (!compiled) throw new Error('expected expression to compile')
+    const batch = loadedBatch([1, 2, 3], ['a', 'b', 'c'])
+    /** @type {RowSelection} */
+    const selection = {
+      type: 'indices',
+      indices: new Uint32Array([2, 0]),
+      length: 3,
+    }
+
+    expect(compiled.evaluate({ batch, selection })).toEqual({
+      type: 'values',
+      values: ['C', 'A'],
+      length: 2,
+    })
+  })
+
+  it('awaits an asynchronous column once per evaluation', async () => {
+    /** @type {ReadColumn} */
+    function readColumn() {
+      return Promise.resolve({ type: 'values', values: ['a', 'bb'], length: 2 })
+    }
+    const read = vi.fn(readColumn)
+    const compiled = compile('LENGTH(text)')
+    if (!compiled) throw new Error('expected expression to compile')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema,
+      selection: { type: 'all', length: 2 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [1, 2], length: 2 } },
+        { type: 'source', read },
+      ],
+    }
+
+    await expect(compiled.evaluate({ batch, selection: batch.selection })).resolves.toEqual({
+      type: 'values',
+      values: [1, 2],
+      length: 2,
+    })
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves scalar short-circuit behavior', () => {
+    const compiled = compile('FALSE AND LENGTH(n) > 0')
+    if (!compiled) throw new Error('expected expression to compile')
+    const batch = loadedBatch([1, 2], ['a', 'b'])
+
+    expect(compiled.evaluate({ batch, selection: batch.selection })).toEqual({
+      type: 'values',
+      values: [false, false],
+      length: 2,
+    })
+  })
+
+  it('declines unsupported expressions and missing identifiers', () => {
+    expect(compileBatchExpression({ expression: expression('COALESCE(n, 0)'), schema })).toBeUndefined()
+    expect(compileBatchExpression({ expression: expression('missing + 1'), schema })).toBeUndefined()
+  })
+})
+
+/**
+ * @param {string} sql
+ * @returns {ReturnType<typeof compileBatchExpression>}
+ */
+function compile(sql) {
+  return compileBatchExpression({ expression: expression(sql), schema })
+}
+
+/**
+ * @param {string} sql
+ * @returns {ExprNode}
+ */
+function expression(sql) {
+  const statement = parseSql({ query: `SELECT ${sql}` })
+  if (statement.type !== 'select') throw new Error('expected select statement')
+  const [column] = statement.columns
+  if (column.type !== 'derived') throw new Error('expected derived column')
+  return column.expr
+}
+
+/**
+ * @param {import('../../src/types.js').SqlPrimitive[]} numbers
+ * @param {import('../../src/types.js').SqlPrimitive[]} texts
+ * @returns {AsyncBatch}
+ */
+function loadedBatch(numbers, texts) {
+  return {
+    schema,
+    selection: { type: 'all', length: numbers.length },
+    columns: [
+      { type: 'loaded', vector: { type: 'values', values: numbers, length: numbers.length } },
+      { type: 'loaded', vector: { type: 'values', values: texts, length: texts.length } },
+    ],
+  }
+}

--- a/test/expression/batch.test.js
+++ b/test/expression/batch.test.js
@@ -3,22 +3,15 @@ import { compileBatchExpression } from '../../src/expression/batch.js'
 import { parseSql } from '../../src/parse/parse.js'
 
 /**
- * @import { AsyncBatch, ReadColumn, RelationSchema, RowSelection } from '../../src/internalTypes.js'
+ * @import { AsyncBatch, ReadColumn, RowSelection } from '../../src/internalTypes.js'
  * @import { ExprNode } from '../../src/types.js'
  */
 
-/** @type {RelationSchema} */
-const schema = {
-  fields: [
-    { id: 0, name: 'n', dataType: { type: 'number' }, nullable: true },
-    { id: 1, name: 'text', dataType: { type: 'string' }, nullable: true },
-  ],
-}
+const schema = ['n', 'text']
 
 describe('batch expressions', () => {
   it('resolves each dependency once for a synchronous vector kernel', () => {
     const compiled = compile('LENGTH(text) + n')
-    expect(compiled?.dependencies).toEqual([1, 0])
     if (!compiled) throw new Error('expected expression to compile')
     const batch = loadedBatch([2, null, 4], ['abc', 'x', null])
 
@@ -60,10 +53,10 @@ describe('batch expressions', () => {
     if (!compiled) throw new Error('expected expression to compile')
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 2 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [1, 2], length: 2 } },
+        { type: 'values', values: [1, 2], length: 2 },
         { type: 'source', read },
       ],
     }
@@ -91,10 +84,10 @@ describe('batch expressions', () => {
     if (!compiled) throw new Error('expected expression to compile')
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 3 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [-1, 1, -2], length: 3 } },
+        { type: 'values', values: [-1, 1, -2], length: 3 },
         { type: 'source', read },
       ],
     }
@@ -122,10 +115,10 @@ describe('batch expressions', () => {
     if (!compiled) throw new Error('expected expression to compile')
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 3 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [1, null, null], length: 3 } },
+        { type: 'values', values: [1, null, null], length: 3 },
         { type: 'source', read },
       ],
     }
@@ -157,10 +150,10 @@ describe('batch expressions', () => {
     if (!compiled) throw new Error('expected expression to compile')
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'all', length: 3 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [1, 0, -1], length: 3 } },
+        { type: 'values', values: [1, 0, -1], length: 3 },
         { type: 'source', read },
       ],
     }
@@ -188,10 +181,10 @@ describe('batch expressions', () => {
     if (!compiled) throw new Error('expected expression to compile')
     /** @type {AsyncBatch} */
     const batch = {
-      schema,
+      columnNames: schema,
       selection: { type: 'indices', indices: new Uint32Array([1, 3]), length: 4 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [0, -1, 0, 1], length: 4 } },
+        { type: 'values', values: [0, -1, 0, 1], length: 4 },
         { type: 'source', read },
       ],
     }
@@ -251,22 +244,16 @@ describe('batch expressions', () => {
   })
 
   it('resolves struct fields before bare columns', () => {
-    /** @type {RelationSchema} */
-    const structSchema = {
-      fields: [
-        { id: 0, name: 'obj', dataType: { type: 'unknown' }, nullable: false },
-        { id: 1, name: 'x', dataType: { type: 'number' }, nullable: false },
-      ],
-    }
-    const compiled = compileBatchExpression({ expression: expression('obj.x'), schema: structSchema })
+    const structSchema = ['obj', 'x']
+    const compiled = compileBatchExpression(expression('obj.x'), structSchema)
     if (!compiled) throw new Error('expected expression to compile')
     /** @type {AsyncBatch} */
     const batch = {
-      schema: structSchema,
+      columnNames: structSchema,
       selection: { type: 'all', length: 2 },
       columns: [
-        { type: 'loaded', vector: { type: 'values', values: [{ x: 2 }, 7], length: 2 } },
-        { type: 'loaded', vector: { type: 'constant', value: 99, length: 2 } },
+        { type: 'values', values: [{ x: 2 }, 7], length: 2 },
+        { type: 'constant', value: 99, length: 2 },
       ],
     }
 
@@ -310,8 +297,8 @@ describe('batch expressions', () => {
   })
 
   it('declines unsupported expressions and missing identifiers', () => {
-    expect(compileBatchExpression({ expression: expression('CASE WHEN n > 0 THEN ABS(n) END'), schema })).toBeUndefined()
-    expect(compileBatchExpression({ expression: expression('missing + 1'), schema })).toBeUndefined()
+    expect(compileBatchExpression(expression('CASE WHEN n > 0 THEN ABS(n) END'), schema)).toBeUndefined()
+    expect(compileBatchExpression(expression('missing + 1'), schema)).toBeUndefined()
   })
 })
 
@@ -320,7 +307,7 @@ describe('batch expressions', () => {
  * @returns {ReturnType<typeof compileBatchExpression>}
  */
 function compile(sql) {
-  return compileBatchExpression({ expression: expression(sql), schema })
+  return compileBatchExpression(expression(sql), schema)
 }
 
 /**
@@ -342,11 +329,11 @@ function expression(sql) {
  */
 function loadedBatch(numbers, texts) {
   return {
-    schema,
+    columnNames: schema,
     selection: { type: 'all', length: numbers.length },
     columns: [
-      { type: 'loaded', vector: { type: 'values', values: numbers, length: numbers.length } },
-      { type: 'loaded', vector: { type: 'values', values: texts, length: texts.length } },
+      { type: 'values', values: numbers, length: numbers.length },
+      { type: 'values', values: texts, length: texts.length },
     ],
   }
 }

--- a/test/expression/batch.test.js
+++ b/test/expression/batch.test.js
@@ -250,6 +250,33 @@ describe('batch expressions', () => {
     })
   })
 
+  it('resolves struct fields before bare columns', () => {
+    /** @type {RelationSchema} */
+    const structSchema = {
+      fields: [
+        { id: 0, name: 'obj', dataType: { type: 'unknown' }, nullable: false },
+        { id: 1, name: 'x', dataType: { type: 'number' }, nullable: false },
+      ],
+    }
+    const compiled = compileBatchExpression({ expression: expression('obj.x'), schema: structSchema })
+    if (!compiled) throw new Error('expected expression to compile')
+    /** @type {AsyncBatch} */
+    const batch = {
+      schema: structSchema,
+      selection: { type: 'all', length: 2 },
+      columns: [
+        { type: 'loaded', vector: { type: 'values', values: [{ x: 2 }, 7], length: 2 } },
+        { type: 'loaded', vector: { type: 'constant', value: 99, length: 2 } },
+      ],
+    }
+
+    expect(compiled.evaluate({ batch, selection: batch.selection })).toEqual({
+      type: 'values',
+      values: [2, 99],
+      length: 2,
+    })
+  })
+
   it('uses a stream row offset in execution errors', () => {
     const compiled = compile('LENGTH(n)')
     if (!compiled) throw new Error('expected expression to compile')

--- a/test/internalBatchTypes.d.ts
+++ b/test/internalBatchTypes.d.ts
@@ -1,0 +1,15 @@
+import type { AsyncDataSource, QueryResults, ScanOptions, ScanResults } from '../src/index.js'
+
+type Assert<T extends true> = T
+type Not<T extends boolean> = T extends true ? false : true
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false
+
+type LegacySource = {
+  columns: string[]
+  scan(options: ScanOptions): ScanResults
+}
+
+type QueryResultsHideBatches = Assert<Not<HasKey<QueryResults, 'batches'>>>
+type QueryResultsHideSchema = Assert<Not<HasKey<QueryResults, 'schema'>>>
+type DataSourcesKeepLegacyContract = Assert<LegacySource extends AsyncDataSource ? true : false>
+type DataSourcesHidePreparedScans = Assert<Not<HasKey<AsyncDataSource, 'prepareScan'>>>


### PR DESCRIPTION
## Summary

- introduce private async column batches and zero-copy row selections
- execute eligible scans, filters, projections, distinct operations, expressions, and streaming aggregates through the internal batch path
- preserve short-circuiting while compiling compound `AND`/`OR`, `CASE`, `NULLIF`, and lazy `COALESCE` expressions over batch selections
- retain row-based fallbacks for unsupported expressions and operators
- bound residual predicate evaluation for finite LIMIT queries with adaptive windows
- keep the public data-source input and query-result APIs unchanged

## Benchmark methodology

- main comparison: master at 6fc535a versus this PR through 9043294
- current PR head: f727552; its additive lazy control-flow expression coverage is measured separately below
- data: updated squirreling-perf Wikipedia parquet data, limited to 100,000 rows
- stock suite: five counterbalanced process runs; figures below are query medians
- analytical suite: ten measured executions per query
- memory cases: median peak RSS from three fresh processes
- result hashes matched master for every stock, analytical, control-flow, and pathological query

## Stock squirreling-perf query shapes

The sum of the 12 query medians fell from 5,210.10 ms to 4,359.38 ms, a 16.3% reduction. The geometric mean of the per-query deltas was 31.4% lower.

| Query shape | Master | PR | Change |
| --- | ---: | ---: | ---: |
| GROUP BY with HAVING | 159.38 ms | 20.97 ms | 7.60x faster |
| UNION ALL over two large filters | 373.79 ms | 144.33 ms | 2.59x faster |
| full-table LEFT JOIN with sparse filtered CTE | 340.46 ms | 197.73 ms | 1.72x faster |
| substring filter scan | 270.53 ms | 163.76 ms | 1.65x faster |
| high-cardinality GROUP BY title | 272.20 ms | 202.96 ms | 1.34x faster |
| derived-key equi self-join | 759.10 ms | 654.56 ms | 13.8% faster |

The remaining stock shapes were close to neutral: computed top-K sort was 3.0% faster, STDDEV was 1.8% faster, title equality was 0.9% faster, multiple scalar aggregates were 0.9% faster, and the full sort was 0.4% faster. Composite DISTINCT measured 1.2% slower, with overlapping timing ranges, so it is treated as noise rather than a regression.

## Batch-eligible analytical shapes

This suite is intentionally curated to exercise the new batch paths; its aggregate should not be interpreted as a general workload average.

| Query shape | Master | PR | Speedup |
| --- | ---: | ---: | ---: |
| normalize titles with COALESCE and UPPER | 384.36 ms | 23.59 ms | 16.30x |
| CAST identifier projection | 249.95 ms | 15.69 ms | 15.93x |
| computed scalar SUM and AVG | 315.82 ms | 23.59 ms | 13.39x |
| computed bucket GROUP BY report | 311.35 ms | 26.30 ms | 11.84x |
| multi-stage CTE filter/project/filter/group | 259.18 ms | 24.42 ms | 10.61x |
| filter plus derived title projection | 220.29 ms | 21.59 ms | 10.20x |
| filtered computed DISTINCT | 178.59 ms | 20.29 ms | 8.80x |
| normalized-title DISTINCT | 404.16 ms | 46.95 ms | 8.61x |
| top-K after a batch pipeline | 144.49 ms | 40.59 ms | 3.56x |
| filtered CTE join | 274.44 ms | 199.53 ms | 1.38x |
| legacy multi-column scan with CASE | 609.10 ms | 586.91 ms | 1.04x |

The final row still uses the row path because the existing public multi-column `scan()` API supplies rows. `CASE` itself is now batch-capable when its input is already a batch.

## Fallback controls

| Control shape | Master | PR | Change |
| --- | ---: | ---: | ---: |
| simple row-only scan | 58.12 ms | 58.06 ms | neutral (-0.1%) |
| row-only computed filter | 131.60 ms | 127.36 ms | 3.2% faster |
| non-streamable aggregate | 200.59 ms | 189.18 ms | 5.7% faster |

## Lazy control-flow expressions

These figures compare master at 6fc535a with the current PR at f727552 on the same updated 100,000-row Wikipedia parquet source. They are medians from nine counterbalanced executions per engine after warmup.

| Query shape | Master | Current PR | Speedup |
| --- | ---: | ---: | ---: |
| compound predicate aggregate | 167.04 ms | 24.74 ms | 6.75x |
| conditional CASE aggregate | 264.94 ms | 25.99 ms | 10.19x |
| NULLIF aggregate | 254.95 ms | 17.71 ms | 14.40x |

Compound predicates evaluate the right side only for rows not decided by the left side. `CASE` evaluates conditions over remaining rows and results only over matching rows. Later `COALESCE` arguments are similarly restricted to rows that remain null. This preserves short-circuit behavior and avoids reading deferred columns for unreachable branches.

## Peak memory

| Query shape | Master RSS | PR RSS | Change |
| --- | ---: | ---: | ---: |
| normalized title projection | 792.6 MiB | 122.1 MiB | 84.6% lower |
| CAST identifier projection | 541.3 MiB | 98.2 MiB | 81.9% lower |
| normalized-title DISTINCT | 578.9 MiB | 131.8 MiB | 77.2% lower |
| bucketed aggregate | 251.9 MiB | 94.9 MiB | 62.3% lower |
| legacy multi-column scan fallback | 1,057.3 MiB | 1,017.6 MiB | 3.8% lower |

The non-streamable aggregate control measured 250.6 MiB on master and 253.6 MiB on the PR, a 3.0 MiB difference treated as noise; its warm heap was lower on the PR.

## Pathological LIMIT behavior

The adaptive filtering commit hardens residual batch filtering when a source returns one very large chunk. These figures compare master, the PR before that hardening, and the hardened PR using a synthetic 100,000-row chunk.

| Query shape | Master | Before hardening | Hardened PR |
| --- | ---: | ---: | ---: |
| dense numeric filter, LIMIT 1 | 0.10 ms | 4.29 ms | 0.14 ms |
| expensive string filter, LIMIT 1 | 0.13 ms | 17.69 ms | 0.19 ms |
| match at the end, LIMIT 1 | 73.72 ms | 3.64 ms | 3.12 ms |
| complete miss, LIMIT 1 | 71.45 ms | 2.61 ms | 3.12 ms |

The complete synthetic miss is about 0.5 ms slower than the pre-hardening PR because it evaluates several windows before consuming the whole chunk. On the updated parquet source, which already yields chunks of 100, 1,000, and 10,000 rows, the corresponding title miss measured 23.89 ms before and 24.09 ms after.

For the expensive early-match case, retained heap fell from 3.02 MiB to 0.68 MiB and peak RSS fell from approximately 75 MiB to 63 MiB.

## Hypaware-shaped workload

The workload was derived from SQL structures observed in local Hypaware query history. The dominant structure was filtered `GROUP BY` with `COUNT(DISTINCT)`, JSON extraction/casts, conditional aggregates, aggregate ordering, and a limit.

Nine of those observed shapes were added to `squirreling-perf` and run over deterministic synthetic telemetry modeled on the `ai_gateway_messages` schema. No captured content is included in the benchmark data. Timings are medians from nine counterbalanced measured executions per engine after warmup.

| Hypaware query shape | Master | PR | Change |
| --- | ---: | ---: | ---: |
| model usage JSON/SUM rollup | 375.90 ms | 370.57 ms | 1.4% faster |
| daily activity with COUNT(DISTINCT) and token sums | 690.76 ms | 669.79 ms | 3.0% faster |
| project token rollup ordered by aggregate | 895.23 ms | 866.72 ms | 3.2% faster |
| filtered tool-usage rollup with LIMIT | 159.03 ms | 156.37 ms | 1.7% faster |
| wide session summary with mixed aggregates | 957.26 ms | 917.70 ms | 4.1% faster |
| JSON request-byte CTE with second aggregation | 920.49 ms | 869.64 ms | 5.5% faster |
| daily conditional agent/tool usage | 580.79 ms | 543.73 ms | 6.4% faster |
| largest-system-prompt preview | 117.96 ms | 115.51 ms | 2.1% faster |
| recent-attributes ordered preview | 191.77 ms | 187.02 ms | 2.5% faster |

The sum of these medians fell from 4,889.19 ms to 4,697.06 ms, a 3.9% reduction. Result hashes matched master for all nine queries.

The final control-flow commit does not materially change these nine timings: each shape currently enters through the legacy multi-column row scan, before the private batch expression compiler can run. The new expression support is groundwork for a future multi-column batch source boundary.

Fresh-process peak RSS measurements were mixed:

| Hypaware query shape | Master RSS | PR RSS | Change |
| --- | ---: | ---: | ---: |
| model usage rollup | 276.0 MiB | 256.1 MiB | 7.2% lower |
| daily activity rollup | 345.1 MiB | 287.5 MiB | 16.7% lower |
| wide session summary | 500.6 MiB | 572.4 MiB | 14.4% higher |
| JSON request-byte CTE | 477.8 MiB | 504.8 MiB | 5.7% higher |
| largest-system-prompt preview | 199.1 MiB | 199.6 MiB | neutral |

This workload shows smaller, more representative speedups than the curated batch-eligible suite and exposes memory regressions in wide/high-cardinality aggregate combinations that the narrower controls did not show.

## Validation

- npm test: 64 files, 1,932 tests passed
- npx tsc
- npm run lint
