### PR TITLE
Backport columnar-independent scope fixes

### DIFF
--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -4,7 +4,7 @@ import { compileBatchExpression } from '../expression/batch.js'
 import { evaluateExpr } from '../expression/evaluate.js'
 import { parseSql } from '../parse/parse.js'
 import { planSql, planStatement } from '../plan/plan.js'
-import { statementScope } from '../plan/columns.js'
+import { collectColumnsFromExpr, statementScope } from '../plan/columns.js'
 import { validateScan, validateTable } from '../validation/tables.js'
 import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
 import { batchResult, batchResultsFor } from './batchResults.js'
@@ -17,7 +17,7 @@ import { executeWindow } from './window.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
- * @import { AsyncBatch, BatchProjection, ColumnVector } from '../internalTypes.js'
+ * @import { AsyncBatch, BatchProjection, ColumnVector, CompiledBatchExpression } from '../internalTypes.js'
  * @import { AsyncCells, AsyncDataSource, AsyncRow, DerivedColumn, ExecuteContext, ExecuteSqlOptions, ExprNode, IdentifierNode, QueryResults, SelectColumn, SqlPrimitive, Statement } from '../types.js'
  * @import { CountNode, DistinctNode, FilterNode, LimitNode, ProjectNode, QueryPlan, ScanNode, SetOperationNode, TableFunctionNode } from '../plan/types.js'
  */
@@ -282,6 +282,7 @@ export function executeScan(plan, context, existingColumnResult) {
   const table = validateTable({ ...plan, tables })
   validateScan({ ...plan, tables })
   const hasLimitOffset = plan.hints.limit !== undefined || plan.hints.offset // 0 offset is noop
+  const scanContext = { ...context, scope: [plan.alias ?? plan.table] }
 
   // Fast path: single column scan. As with scan(), hints the source did not
   // apply are handled by the engine over the returned column values.
@@ -353,7 +354,7 @@ export function executeScan(plan, context, existingColumnResult) {
           }
         })()
 
-        result = filterRows(result, plan.hints.where, context, plan.hints.limit)
+        result = filterRows(result, plan.hints.where, scanContext, plan.hints.limit)
         // Filtered LIMIT/OFFSET was intentionally not passed to scanColumn.
         if (!appliedLimitOffset && hasLimitOffset) {
           result = limitRows(result, plan.hints.limit, plan.hints.offset, signal)
@@ -386,7 +387,7 @@ export function executeScan(plan, context, existingColumnResult) {
 
       // Apply WHERE if data source did not
       if (!appliedWhere && plan.hints.where) {
-        result = filterRows(result, plan.hints.where, context, plan.hints.limit)
+        result = filterRows(result, plan.hints.where, scanContext, plan.hints.limit)
       }
 
       // Apply LIMIT/OFFSET if data source did not
@@ -546,6 +547,41 @@ async function* limitRows(rows, limit = Infinity, offset = 0, signal) {
 }
 
 /**
+ * Compiles a batch expression only when qualified identifiers do not depend
+ * on current or outer row scope.
+ *
+ * @param {ExprNode} expression
+ * @param {string[]} columns
+ * @param {ExecuteContext} context
+ * @returns {CompiledBatchExpression | undefined}
+ */
+function compileUnscopedBatchExpression(expression, columns, context) {
+  return referencesRowScope(expression, columns, context)
+    ? undefined
+    : compileBatchExpression(expression, columns)
+}
+
+/**
+ * Returns whether an expression reads a qualified identifier from row scope.
+ *
+ * @param {ExprNode} expression
+ * @param {string[]} columns
+ * @param {ExecuteContext} context
+ * @returns {boolean}
+ */
+function referencesRowScope(expression, columns, context) {
+  /** @type {IdentifierNode[]} */
+  const identifiers = []
+  collectColumnsFromExpr(expression, identifiers)
+  return identifiers.some(function scopedIdentifier(identifier) {
+    return Boolean(identifier.prefix && (
+      context.outerAliases?.has(identifier.prefix) ||
+      context.scope?.includes(identifier.prefix) && columns.includes(identifier.prefix)
+    ))
+  })
+}
+
+/**
  * Executes a filter operation (WHERE clause)
  *
  * @param {FilterNode} plan
@@ -556,7 +592,7 @@ function executeFilter(plan, context) {
   const child = executePlan({ plan: plan.child, context })
   const childBatches = batchResultsFor(child)
   const expression = childBatches
-    ? compileBatchExpression(plan.condition, childBatches.columns)
+    ? compileUnscopedBatchExpression(plan.condition, childBatches.columns, context)
     : undefined
   if (expression && childBatches) {
     const readChildBatches = childBatches.batches
@@ -589,13 +625,18 @@ function executeProject(plan, context) {
   const child = executePlan({ plan: plan.child, context })
   const columns = selectColumnNames(plan.columns, child.columns)
 
-  const resolveable = plan.columns.every(col =>
-    col.type === 'star' || col.type === 'derived' && col.expr.type === 'identifier'
-  )
+  const resolveable = plan.columns.every(function resolvesDirectly(column) {
+    if (column.type === 'star') return true
+    if (column.expr.type !== 'identifier') return false
+    const sourceName = column.expr.prefix
+      ? `${column.expr.prefix}.${column.expr.name}`
+      : column.expr.name
+    return child.columns.includes(sourceName)
+  })
 
   const childBatches = batchResultsFor(child)
   const projection = childBatches
-    ? batchProjection(plan.columns, columns, child.columns)
+    ? batchProjection(plan.columns, columns, child.columns, context)
     : undefined
   if (projection && childBatches) {
     const readChildBatches = childBatches.batches
@@ -861,9 +902,10 @@ function isNumericArray(values) {
  * @param {SelectColumn[]} planColumns
  * @param {string[]} outputColumns
  * @param {string[]} childColumns
+ * @param {ExecuteContext} context
  * @returns {BatchProjection[] | undefined}
  */
-function batchProjection(planColumns, outputColumns, childColumns) {
+function batchProjection(planColumns, outputColumns, childColumns, context) {
   /** @type {BatchProjection[]} */
   const projections = []
   for (const column of planColumns) {
@@ -876,6 +918,8 @@ function batchProjection(planColumns, outputColumns, childColumns) {
       }
       continue
     }
+
+    if (referencesRowScope(column.expr, childColumns, context)) return undefined
 
     if (column.expr.type === 'literal') {
       projections.push({ type: 'constant', value: column.expr.value })
@@ -932,11 +976,13 @@ function identifierColumnIndex(identifier, childColumns) {
  */
 function executeSetOperation(plan, context) {
   const { signal } = context
+  const leftContext = plan.leftScope === undefined ? context : { ...context, scope: plan.leftScope }
+  const rightContext = plan.rightScope === undefined ? context : { ...context, scope: plan.rightScope }
+  const left = executePlan({ plan: plan.left, context: leftContext })
+  const right = executePlan({ plan: plan.right, context: rightContext })
 
   if (plan.operator === 'UNION') {
     if (plan.all) {
-      const left = executePlan({ plan: plan.left, context })
-      const right = executePlan({ plan: plan.right, context })
       return {
         columns: left.columns,
         numRows: addBounds(left.numRows, right.numRows),
@@ -948,8 +994,6 @@ function executeSetOperation(plan, context) {
         },
       }
     } else {
-      const left = executePlan({ plan: plan.left, context })
-      const right = executePlan({ plan: plan.right, context })
       return {
         columns: left.columns,
         maxRows: addBounds(left.maxRows, right.maxRows),
@@ -985,8 +1029,6 @@ function executeSetOperation(plan, context) {
       }
     }
   } else if (plan.operator === 'INTERSECT') {
-    const left = executePlan({ plan: plan.left, context })
-    const right = executePlan({ plan: plan.right, context })
     return {
       columns: left.columns,
       maxRows: minBounds(left.maxRows, right.maxRows),
@@ -1040,8 +1082,6 @@ function executeSetOperation(plan, context) {
     }
   } else {
     // EXCEPT
-    const left = executePlan({ plan: plan.left, context })
-    const right = executePlan({ plan: plan.right, context })
     return {
       columns: left.columns,
       maxRows: left.maxRows,

--- a/src/execute/streamingAggregate.js
+++ b/src/execute/streamingAggregate.js
@@ -431,12 +431,14 @@ async function accumulateChunk({ chunk, groupBy, specs, groups, needsRow, contex
  * @param {ExprNode[]} groupBy
  * @param {StreamingAggSpec[]} specs
  * @param {readonly string[]} columns
+ * @param {ExecuteContext} context
  * @returns {BatchAggregateInputs | undefined}
  */
-function compileBatchAggregateInputs(groupBy, specs, columns) {
+function compileBatchAggregateInputs(groupBy, specs, columns, context) {
   /** @type {CompiledBatchExpression[]} */
   const keys = []
   for (const expression of groupBy) {
+    if (referencesOuterScope(expression, context)) return undefined
     const key = compileBatchExpression(expression, columns)
     if (!key) return undefined
     keys.push(key)
@@ -448,6 +450,8 @@ function compileBatchAggregateInputs(groupBy, specs, columns) {
   const args = []
   for (const spec of specs) {
     if (spec.node.filter && !spec.star) return undefined
+    if (spec.node.filter && referencesOuterScope(spec.node.filter, context)) return undefined
+    if (!spec.star && referencesOuterScope(spec.node.args[0], context)) return undefined
     const filter = spec.node.filter
       ? compileBatchExpression(spec.node.filter, columns)
       : undefined
@@ -463,6 +467,25 @@ function compileBatchAggregateInputs(groupBy, specs, columns) {
     filters,
     args,
   }
+}
+
+/**
+ * Returns whether an expression reads a qualified identifier from the
+ * enclosing query rather than the current aggregate input.
+ *
+ * @param {ExprNode} expression
+ * @param {ExecuteContext} context
+ * @returns {boolean}
+ */
+function referencesOuterScope(expression, context) {
+  /** @type {IdentifierNode[]} */
+  const identifiers = []
+  collectColumnsFromExpr(expression, identifiers)
+  return identifiers.some(function isOuterReference(identifier) {
+    return Boolean(identifier.prefix &&
+      context.outerAliases?.has(identifier.prefix) &&
+      !context.scope?.includes(identifier.prefix))
+  })
 }
 
 /**
@@ -553,7 +576,7 @@ async function accumulateGroups({ child, groupBy, specs, needsRow, context }) {
   const groups = new Map()
   const batchResults = batchResultsFor(child)
   const batchInputs = batchResults && !needsRow
-    ? compileBatchAggregateInputs(groupBy, specs, batchResults.columns)
+    ? compileBatchAggregateInputs(groupBy, specs, batchResults.columns, context)
     : undefined
   if (batchInputs && batchResults) {
     let rowOffset = 0

--- a/src/expression/evaluate.js
+++ b/src/expression/evaluate.js
@@ -75,6 +75,13 @@ export async function evaluateExpr({ node, row, rowIndex, rows, context }) {
       if (qualified in row.cells) {
         return row.cells[qualified]()
       }
+      if (context.scope?.includes(node.prefix) && node.name in row.cells) {
+        return row.cells[node.name]()
+      }
+      if (context.outerRow && context.outerAliases?.has(node.prefix)) {
+        if (qualified in context.outerRow.cells) return context.outerRow.cells[qualified]()
+        if (node.name in context.outerRow.cells) return context.outerRow.cells[node.name]()
+      }
       const prefix = node.prefix + '.'
       const prefixedColumns = row.columns.filter(col => col.startsWith(prefix))
       if (prefixedColumns.length === 1) {
@@ -93,10 +100,6 @@ export async function evaluateExpr({ node, row, rowIndex, rows, context }) {
         if (isPlainObject(value) && Object.prototype.hasOwnProperty.call(value, node.name)) {
           return value[node.name]
         }
-      }
-      // Check outer row for correlated subquery references
-      if (context.outerRow && context.outerAliases?.has(node.prefix) && node.name in context.outerRow.cells) {
-        return context.outerRow.cells[node.name]()
       }
       // Standalone `FROM UNNEST(...) AS alias` row has a single bare column;
       // `alias.field` should struct-access that column's element.

--- a/src/plan/columns.js
+++ b/src/plan/columns.js
@@ -60,9 +60,10 @@ export function tableFunctionColumnNames(from) {
  * @param {object} options
  * @param {SelectStatement} options.select
  * @param {IdentifierNode[]} [options.parentColumns] - columns needed by the parent query
+ * @param {Set<string>} [options.scopeColumns] - bare column names available in the current scope
  * @returns {Map<string, string[] | undefined>}
  */
-export function extractColumns({ select, parentColumns }) {
+export function extractColumns({ select, parentColumns, scopeColumns }) {
   /** @type {Map<string, string[] | undefined>} */
   const result = new Map()
 
@@ -175,9 +176,18 @@ export function extractColumns({ select, parentColumns }) {
   // Partition identifiers by table prefix
   for (const { prefix, name } of identifiers) {
     if (prefix) {
-      // Qualified: add to matching table only
-      const set = perTable.get(prefix)
-      if (set) set.add(name)
+      if (perTable.has(prefix)) {
+        // Table-qualified: add to the matching table only
+        perTable.get(prefix)?.add(name)
+      } else if (scopeColumns?.has(prefix)) {
+        // Struct-field access: the prefix is the source column being read.
+        if (aliases.length === 1) {
+          perTable.get(aliases[0])?.add(prefix)
+        } else {
+          // As with an unqualified column in a join, its owner is ambiguous.
+          for (const alias of aliases) perTable.set(alias, undefined)
+        }
+      }
     } else if (aliases.length > 1) {
       // Unqualified in a JOIN: can't disambiguate, request all columns from all tables
       for (const alias of aliases) {

--- a/src/plan/plan.js
+++ b/src/plan/plan.js
@@ -82,6 +82,8 @@ function planSetOperation({ compound, ctePlans, cteColumns, tables, parentColumn
     all: compound.all,
     left,
     right,
+    leftScope: statementScope(compound.left),
+    rightScope: statementScope(compound.right),
   }
 
   if (compound.orderBy.length) {
@@ -206,7 +208,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
   // included so they are only applied to fresh scans, not CTE/subquery plans)
   /** @type {ScanOptions} */
   const hints = {}
-  const perTableColumns = extractColumns({ select: originalSelect, parentColumns })
+  const perTableColumns = extractColumns({ select: originalSelect, parentColumns, scopeColumns })
   if (sourceAlias !== undefined) hints.columns = perTableColumns.get(sourceAlias)
   // Capture what the parent reads from a FROM subquery before the reset
   // below, so aggregate outputs it never reads can still be pruned when the
@@ -406,7 +408,7 @@ function planFrom({ select, ctePlans, cteColumns, hints, tables, outerScope }) {
       return ctePlan
     }
     validateScan({ ...select.from, hints, tables })
-    return { type: 'Scan', table: select.from.table, hints }
+    return { type: 'Scan', table: select.from.table, alias: select.from.alias, hints }
   } else if (select.from.type === 'function') {
     for (const arg of select.from.args) {
       validateNoIdentifiers(arg, select.from.funcName, outerScope)
@@ -545,7 +547,7 @@ function planJoin({ left, joins, leftTable, ctePlans, cteColumns, perTableColumn
         // For CTE joins, use CTE column metadata for hints
         rightHints.columns = perTableColumns.get(rightTable) ?? cteColumns?.get(join.table.toLowerCase())
       }
-      rightScan = ctePlan ?? { type: 'Scan', table: join.table, hints: rightHints }
+      rightScan = ctePlan ?? { type: 'Scan', table: join.table, alias: join.alias, hints: rightHints }
     }
 
     if (join.joinType === 'POSITIONAL') {

--- a/src/plan/types.d.ts
+++ b/src/plan/types.d.ts
@@ -23,6 +23,7 @@ export type QueryPlan =
 export interface ScanNode {
   type: 'Scan'
   table: string
+  alias?: string
   hints: ScanOptions
 }
 
@@ -130,6 +131,8 @@ export interface SetOperationNode {
   all: boolean
   left: QueryPlan
   right: QueryPlan
+  leftScope?: string[]
+  rightScope?: string[]
 }
 
 // Wraps a derived-table or CTE subplan with the lexical alias scope of its

--- a/test/execute/batchAggregate.test.js
+++ b/test/execute/batchAggregate.test.js
@@ -56,6 +56,21 @@ describe('private batch aggregate execution', () => {
       query: 'SELECT SUM(obj.x) AS total FROM (SELECT id AS obj, 99 AS x FROM data)',
     }))).resolves.toEqual([{ total: 5 }])
   })
+
+  it('preserves outer references in aggregate inputs', async () => {
+    await expect(collect(executeSql({
+      tables: {
+        users: [{ id: 1 }, { id: 2 }],
+        orders: columnSource([10, 20]),
+      },
+      query: `SELECT u.id,
+        (SELECT SUM(u.id + id) FROM orders) AS total
+        FROM users u ORDER BY u.id`,
+    }))).resolves.toEqual([
+      { id: 1, total: 32 },
+      { id: 2, total: 34 },
+    ])
+  })
 })
 
 /**

--- a/test/execute/batchExecution.test.js
+++ b/test/execute/batchExecution.test.js
@@ -12,7 +12,7 @@ describe('native batch execution', () => {
     const source = columnSource(function chunks() { return [values] })
     const results = executeSql({
       tables: { data: source },
-      query: 'SELECT id AS value FROM data',
+      query: 'SELECT data.id AS value FROM data',
     })
 
     expect(Object.keys(results)).toEqual(['columns', 'numRows', 'maxRows', 'rows'])
@@ -176,6 +176,34 @@ describe('native batch execution', () => {
     expect(await collect(results)).toEqual([{ value: 3 }])
   })
 
+  it('preserves outer scope in filters above private batch subqueries', async () => {
+    const orders = columnSource(function chunks() { return [[1]] }, true, 'user_id')
+
+    await expect(collect(executeSql({
+      tables: { users: [{ id: 1 }, { id: 2 }], orders },
+      query: `SELECT u.id FROM users u
+        WHERE EXISTS (
+          SELECT 1 FROM (SELECT user_id AS id FROM orders) q
+          WHERE q.id = u.id
+        )
+        ORDER BY u.id`,
+    }))).resolves.toEqual([{ id: 1 }])
+  })
+
+  it('preserves outer scope in private batch projections', async () => {
+    const items = columnSource(function chunks() { return [[{ id: 99 }]] }, true, 'u')
+
+    await expect(collect(executeSql({
+      tables: { users: [{ id: 1 }, { id: 2 }], items },
+      query: `SELECT u.id,
+        (SELECT CASE WHEN u IS NOT NULL THEN u.id ELSE 0 END FROM items) AS projected
+        FROM users u ORDER BY u.id`,
+    }))).resolves.toEqual([
+      { id: 1, projected: 1 },
+      { id: 2, projected: 2 },
+    ])
+  })
+
   it('executes distinct over private computed batches', async () => {
     const source = columnSource(function chunks() { return [[1, 2, 3], [4, 5]] })
     const results = executeSql({
@@ -214,11 +242,12 @@ describe('native batch execution', () => {
 /**
  * @param {() => ArrayLike<import('../../src/types.js').SqlPrimitive>[]} readChunks
  * @param {boolean} [appliedLimitOffset]
+ * @param {string} [column]
  * @returns {AsyncDataSource}
  */
-function columnSource(readChunks, appliedLimitOffset = true) {
+function columnSource(readChunks, appliedLimitOffset = true, column = 'id') {
   return {
-    columns: ['id'],
+    columns: [column],
     scan: vi.fn(function scan() {
       throw new Error('row scan should not be called')
     }),

--- a/test/execute/execute.cte.test.js
+++ b/test/execute/execute.cte.test.js
@@ -247,6 +247,27 @@ describe('CTE execution', () => {
     })
   })
 
+  it('should preserve table alias precedence inside a CTE', async () => {
+    const rows = [{ t: { keep: false }, keep: true }]
+
+    await expect(collect(executeSql({
+      tables: { rows },
+      query: 'WITH q AS (SELECT t FROM rows t WHERE t.keep) SELECT * FROM q',
+    }))).resolves.toEqual([{ t: { keep: false } }])
+
+    await expect(collect(executeSql({
+      tables: { rows },
+      query: `WITH q AS (
+          SELECT t FROM rows t WHERE t.keep
+          UNION ALL
+          SELECT t FROM rows t WHERE t.keep
+        ) SELECT * FROM q`,
+    }))).resolves.toEqual([
+      { t: { keep: false } },
+      { t: { keep: false } },
+    ])
+  })
+
   describe('CTE in expression subquery', () => {
     it('should resolve CTE in a scalar subquery', async () => {
       const result = await collect(executeSql({

--- a/test/execute/execute.dot.test.js
+++ b/test/execute/execute.dot.test.js
@@ -143,6 +143,29 @@ describe('columns with dots in names', () => {
     })
   })
 
+  describe('struct field references', () => {
+    it('should project a struct field', async () => {
+      const rows = [{ obj: { x: 1 } }, { obj: { x: 2 } }]
+
+      await expect(collect(executeSql({
+        tables: { rows },
+        query: 'SELECT obj.x FROM rows',
+      }))).resolves.toEqual([{ x: 1 }, { x: 2 }])
+    })
+
+    it('should order by a struct field', async () => {
+      const rows = [
+        { obj: { x: 2 }, payload: 'second' },
+        { obj: { x: 1 }, payload: 'first' },
+      ]
+
+      await expect(collect(executeSql({
+        tables: { rows },
+        query: 'SELECT payload FROM rows ORDER BY obj.x',
+      }))).resolves.toEqual([{ payload: 'first' }, { payload: 'second' }])
+    })
+  })
+
   describe('table-qualified column references', () => {
     it('should resolve table.column for regular columns', async () => {
       const result = await collect(executeSql({
@@ -181,6 +204,15 @@ describe('columns with dots in names', () => {
         { x: 2, real_x: 1 },
         { x: 1, real_x: 2 },
       ])
+    })
+
+    it('should prefer a table alias over a struct column', async () => {
+      const rows = [{ d: { keep: false }, keep: true }]
+
+      await expect(collect(executeSql({
+        tables: { rows },
+        query: 'SELECT d FROM rows d WHERE d.keep',
+      }))).resolves.toEqual([{ d: { keep: false } }])
     })
   })
 

--- a/test/execute/streamingAggregate.test.js
+++ b/test/execute/streamingAggregate.test.js
@@ -513,6 +513,42 @@ describe('streaming aggregate results', () => {
     ])
   })
 
+  it('preserves table-alias precedence in aggregate inputs', async () => {
+    const rows = [
+      { d: { keep: false }, keep: true },
+      { d: { keep: false }, keep: true },
+    ]
+
+    await expect(collect(executeSql({
+      tables: { rows },
+      query: `SELECT d.keep AS grouped, MAX(d) AS max_d, COUNTIF(d.keep) AS matching
+        FROM rows d GROUP BY d.keep`,
+    }))).resolves.toEqual([{
+      grouped: true,
+      max_d: { keep: false },
+      matching: 2,
+    }])
+  })
+
+  it('preserves each set operand scope in aggregate inputs', async () => {
+    const rows = [
+      { d: { keep: false }, e: { keep: false }, keep: true },
+      { d: { keep: false }, e: { keep: false }, keep: true },
+    ]
+
+    await expect(collect(executeSql({
+      tables: { rows },
+      query: `SELECT d.keep AS grouped, MAX(d) AS max_d, COUNTIF(d.keep) AS matching
+        FROM rows d GROUP BY d.keep
+        UNION ALL
+        SELECT e.keep AS grouped, MAX(e) AS max_d, COUNTIF(e.keep) AS matching
+        FROM rows e GROUP BY e.keep`,
+    }))).resolves.toEqual([
+      { grouped: true, max_d: { keep: false }, matching: 2 },
+      { grouped: true, max_d: { keep: false }, matching: 2 },
+    ])
+  })
+
   it('evaluates bigint literals alongside streamed aggregates', async () => {
     const result = await collect(executeSql({
       tables,


### PR DESCRIPTION
## Summary

- preserve table and outer-row scope across scans, private batches, aggregates, CTEs, and set operations
- request struct base columns for projection and ordering
- prevent unresolved projections from advertising incomplete materialized rows
- add nine regressions using APIs already supported by master

Prepared-scan contracts, demand scheduling, caching, and residual execution remain scoped to columnar-design.

## Validation

- npm test: 1,945 passed
- npm run lint
- npx tsc