### PR TITLE
Fix native batch async fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - run: npm i
       - run: npm run lint
 
@@ -17,6 +20,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - run: npm i
       - run: npx tsc
 
@@ -25,5 +31,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - run: npm i
       - run: npm run coverage

--- a/src/backend/batch.js
+++ b/src/backend/batch.js
@@ -18,6 +18,35 @@ export function selectedRowCount(selection) {
 }
 
 /**
+ * Recognizes promises and thenables without relying on realm identity.
+ *
+ * @template T
+ * @param {T | PromiseLike<T>} value
+ * @returns {value is PromiseLike<T>}
+ */
+export function isPromiseLike(value) {
+  if (value === null || typeof value !== 'object' && typeof value !== 'function') return false
+  return typeof Reflect.get(value, 'then') === 'function'
+}
+
+/**
+ * Avoids a promise boundary when every column is already loaded synchronously.
+ *
+ * @param {ColumnResult[]} results
+ * @returns {ColumnVector[] | Promise<ColumnVector[]>}
+ */
+export function resolveColumnResults(results) {
+  if (results.some(isPromiseLike)) return Promise.all(results)
+  /** @type {ColumnVector[]} */
+  const vectors = []
+  for (const result of results) {
+    if (isPromiseLike(result)) throw new Error('Unexpected asynchronous column result')
+    vectors.push(result)
+  }
+  return vectors
+}
+
+/**
  * Creates base-aligned ordinal values for the rows in a selection.
  *
  * @param {RowSelection} selection
@@ -158,8 +187,8 @@ export function readBatchColumn({ batch, columnIndex, selection = batch.selectio
       : undefined,
   })
   const validated = validateColumnResult(result, selectedRowCount(selection))
-  if (validated instanceof Promise) {
-    const settled = validated.then(function cacheResolved(vector) {
+  if (isPromiseLike(validated)) {
+    const settled = Promise.resolve(validated).then(function cacheResolved(vector) {
       cache.pending.delete(signal)
       cache.resolved ??= vector
       return vector
@@ -215,8 +244,8 @@ function selectionIndexAt(selection, index) {
  * @returns {ColumnResult}
  */
 function validateColumnResult(result, expectedLength) {
-  if (result instanceof Promise) {
-    return result.then(function validateResolvedVector(vector) {
+  if (isPromiseLike(result)) {
+    return Promise.resolve(result).then(function validateResolvedVector(vector) {
       return validateVectorLength(vector, expectedLength)
     })
   }

--- a/src/backend/batchAdapters.js
+++ b/src/backend/batchAdapters.js
@@ -1,8 +1,8 @@
-import { readBatchColumn, selectVector, selectedRowCount, valueAt } from './batch.js'
+import { readBatchColumn, resolveColumnResults, selectVector, selectedRowCount, valueAt } from './batch.js'
 import { yieldToEventLoop } from '../execute/yield.js'
 
 /**
- * @import { AsyncBatch, AsyncCells, AsyncRow, ColumnResult, ColumnVector, RowsToBatchesOptions, SqlPrimitive } from '../types.js'
+ * @import { AsyncBatch, AsyncCells, AsyncRow, RowsToBatchesOptions, SqlPrimitive } from '../types.js'
  */
 
 const DEFAULT_BATCH_ROWS = 1024
@@ -21,24 +21,19 @@ export async function* rowsToBatches(rows, columnNames, options) {
   if (!Number.isInteger(batchRows) || batchRows <= 0) {
     throw new RangeError(`batchRows must be a positive integer, got ${batchRows}`)
   }
-  let values = makeValueBuffers(columnNames.length)
-  let rowCount = 0
+  /** @type {AsyncRow[]} */
+  let bufferedRows = []
 
   for await (const row of rows) {
     options?.signal?.throwIfAborted()
-    for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
-      const name = columnNames[columnIndex]
-      values[columnIndex].push(await readRowCell(row, name))
-    }
-    rowCount++
-    if (rowCount === batchRows) {
-      yield loadedBatch(values, rowCount)
-      values = makeValueBuffers(columnNames.length)
-      rowCount = 0
+    bufferedRows.push(row)
+    if (bufferedRows.length === batchRows) {
+      yield await materializeRows(bufferedRows, columnNames)
+      bufferedRows = []
     }
   }
 
-  if (rowCount > 0) yield loadedBatch(values, rowCount)
+  if (bufferedRows.length > 0) yield await materializeRows(bufferedRows, columnNames)
   options?.signal?.throwIfAborted()
 }
 
@@ -100,7 +95,7 @@ export async function collectBatches(batches, names, signal) {
     const results = batch.columns.map(function readColumn(_column, columnIndex) {
       return readBatchColumn({ batch, columnIndex, signal })
     })
-    const vectors = await resolveColumns(results)
+    const vectors = await resolveColumnResults(results)
     const rowCount = selectedRowCount(batch.selection)
     for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       if (signal && rowIndex % 4000 === 0) {
@@ -134,6 +129,27 @@ async function readRowCell(row, name) {
 }
 
 /**
+ * @param {AsyncRow[]} rows
+ * @param {string[]} columnNames
+ * @returns {Promise<AsyncBatch>}
+ */
+async function materializeRows(rows, columnNames) {
+  const values = makeValueBuffers(columnNames.length)
+  /** @type {Promise<void>[]} */
+  const pendingReads = []
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    for (let columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
+      const name = columnNames[columnIndex]
+      pendingReads.push(readRowCell(rows[rowIndex], name).then(function storeValue(value) {
+        values[columnIndex][rowIndex] = value
+      }))
+    }
+  }
+  await Promise.all(pendingReads)
+  return loadedBatch(values, rows.length)
+}
+
+/**
  * @param {number} count
  * @returns {SqlPrimitive[][]}
  */
@@ -156,23 +172,4 @@ function loadedBatch(values, rowCount) {
       return { type: 'values', values: columnValues, length: rowCount }
     }),
   }
-}
-
-/**
- * Avoids a promise boundary when every column is already loaded synchronously.
- *
- * @param {ColumnResult[]} results
- * @returns {ColumnVector[] | Promise<ColumnVector[]>}
- */
-function resolveColumns(results) {
-  if (results.some(function isPromise(result) { return result instanceof Promise })) {
-    return Promise.all(results)
-  }
-  /** @type {ColumnVector[]} */
-  const vectors = []
-  for (const result of results) {
-    if (result instanceof Promise) throw new Error('Unexpected asynchronous column result')
-    vectors.push(result)
-  }
-  return vectors
 }

--- a/src/execute/batches.js
+++ b/src/execute/batches.js
@@ -1,10 +1,10 @@
-import { readBatchColumn, selectBatch, selectedRowCount, selectionOrdinals, valueAt } from '../backend/batch.js'
+import { isPromiseLike, readBatchColumn, resolveColumnResults, selectBatch, selectedRowCount, selectionOrdinals, valueAt } from '../backend/batch.js'
 import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
 
 /**
  * @import { BatchProjection, CompiledBatchExpression } from '../internalTypes.js'
- * @import { AsyncBatch, BatchColumn, ColumnResult, ColumnVector, ReadColumn, RowSelection, SqlPrimitive } from '../types.js'
+ * @import { AsyncBatch, BatchColumn, ColumnVector, ReadColumn, RowSelection, SqlPrimitive } from '../types.js'
  */
 
 const INITIAL_FILTER_WINDOW_ROWS = 256
@@ -95,7 +95,7 @@ export async function* filterBatches(batches, expression, signal, targetRows) {
         signal,
         rowOffset: rowOffset + start,
       })
-      const predicate = result instanceof Promise ? await result : result
+      const predicate = isPromiseLike(result) ? await result : result
       const { selection, selectedCount } = predicateSelection(predicate, windowRowCount)
       start = end
       matchedRows += selectedCount
@@ -138,8 +138,8 @@ export async function* distinctBatches(batches, signal) {
     const results = batch.columns.map(function readColumn(_column, columnIndex) {
       return readBatchColumn({ batch, columnIndex, signal })
     })
-    const resolved = resolveVectors(results)
-    const vectors = resolved instanceof Promise ? await resolved : resolved
+    const resolved = resolveColumnResults(results)
+    const vectors = isPromiseLike(resolved) ? await resolved : resolved
     const rowCount = selectedRowCount(batch.selection)
     const indices = new Uint32Array(rowCount)
     /** @type {SqlPrimitive[]} */
@@ -254,21 +254,4 @@ function predicateSelection(predicate, rowCount) {
     selection: { type: 'indices', indices: indices.subarray(0, selectedCount), length: rowCount },
     selectedCount,
   }
-}
-
-/**
- * @param {ColumnResult[]} results
- * @returns {ColumnVector[] | Promise<ColumnVector[]>}
- */
-function resolveVectors(results) {
-  if (results.some(function isPromise(result) { return result instanceof Promise })) {
-    return Promise.all(results)
-  }
-  /** @type {ColumnVector[]} */
-  const vectors = []
-  for (const result of results) {
-    if (result instanceof Promise) throw new Error('Unexpected asynchronous column result')
-    vectors.push(result)
-  }
-  return vectors
 }

--- a/src/execute/execute.js
+++ b/src/execute/execute.js
@@ -12,6 +12,7 @@ import { executeHashAggregate, executeScalarAggregate } from './aggregates.js'
 import { batchResult } from './batchResults.js'
 import { distinctBatches, filterBatches, limitBatches, projectExpressionBatches } from './batches.js'
 import { executeHashJoin, executeNestedLoopJoin, executePositionalJoin } from './join.js'
+import { referencesRowScope } from './rowScope.js'
 import { normalizeScanColumnResult } from './scanColumn.js'
 import { executeSort } from './sort.js'
 import { addBounds, minBounds, stableRowKey } from './utils.js'
@@ -718,26 +719,6 @@ function compileUnscopedBatchExpression(expression, columns, context) {
   return referencesRowScope(expression, columns, context)
     ? undefined
     : compileBatchExpression(expression, columns)
-}
-
-/**
- * Returns whether an expression reads a qualified identifier from row scope.
- *
- * @param {ExprNode} expression
- * @param {string[]} columns
- * @param {ExecuteContext} context
- * @returns {boolean}
- */
-function referencesRowScope(expression, columns, context) {
-  /** @type {IdentifierNode[]} */
-  const identifiers = []
-  collectColumnsFromExpr(expression, identifiers)
-  return identifiers.some(function scopedIdentifier(identifier) {
-    return Boolean(identifier.prefix && (
-      context.outerAliases?.has(identifier.prefix) ||
-      context.scope?.includes(identifier.prefix) && columns.includes(identifier.prefix)
-    ))
-  })
 }
 
 /**

--- a/src/execute/rowScope.js
+++ b/src/execute/rowScope.js
@@ -1,0 +1,27 @@
+import { collectColumnsFromExpr } from '../plan/columns.js'
+
+/**
+ * @import { ExecuteContext, ExprNode, IdentifierNode } from '../types.js'
+ */
+
+/**
+ * Returns whether an expression reads a qualified identifier from row scope.
+ * A current-scope prefix is ambiguous only when it is also a child column and
+ * could therefore mean struct-field access.
+ *
+ * @param {ExprNode} expression
+ * @param {readonly string[]} columns
+ * @param {ExecuteContext} context
+ * @returns {boolean}
+ */
+export function referencesRowScope(expression, columns, context) {
+  /** @type {IdentifierNode[]} */
+  const identifiers = []
+  collectColumnsFromExpr(expression, identifiers)
+  return identifiers.some(function scopedIdentifier(identifier) {
+    return Boolean(identifier.prefix && (
+      context.outerAliases?.has(identifier.prefix) ||
+      context.scope?.includes(identifier.prefix) && columns.includes(identifier.prefix)
+    ))
+  })
+}

--- a/src/execute/streamingAggregate.js
+++ b/src/execute/streamingAggregate.js
@@ -5,6 +5,7 @@ import { evaluateAll, evaluateExpr } from '../expression/evaluate.js'
 import { collectColumnsFromExpr } from '../plan/columns.js'
 import { isAggregateFunc } from '../validation/functions.js'
 import { finalizeAccumulator, newAccumulator, updateAccumulator } from './accumulator.js'
+import { referencesRowScope } from './rowScope.js'
 import { sortEntriesByTerms } from './sort.js'
 import { keyify } from './utils.js'
 import { yieldToEventLoop } from './yield.js'
@@ -437,7 +438,7 @@ function compileBatchAggregateInputs(groupBy, specs, columns, context) {
   /** @type {CompiledBatchExpression[]} */
   const keys = []
   for (const expression of groupBy) {
-    if (referencesRowScope(expression, context)) return undefined
+    if (referencesRowScope(expression, columns, context)) return undefined
     const key = compileBatchExpression(expression, columns)
     if (!key) return undefined
     keys.push(key)
@@ -449,8 +450,8 @@ function compileBatchAggregateInputs(groupBy, specs, columns, context) {
   const args = []
   for (const spec of specs) {
     if (spec.node.filter && !spec.star) return undefined
-    if (spec.node.filter && referencesRowScope(spec.node.filter, context)) return undefined
-    if (!spec.star && referencesRowScope(spec.node.args[0], context)) return undefined
+    if (spec.node.filter && referencesRowScope(spec.node.filter, columns, context)) return undefined
+    if (!spec.star && referencesRowScope(spec.node.args[0], columns, context)) return undefined
     const filter = spec.node.filter
       ? compileBatchExpression(spec.node.filter, columns)
       : undefined
@@ -466,25 +467,6 @@ function compileBatchAggregateInputs(groupBy, specs, columns, context) {
     filters,
     args,
   }
-}
-
-/**
- * Returns whether an expression reads a qualified identifier whose table
- * scope the batch compiler cannot distinguish from struct-field access.
- *
- * @param {ExprNode} expression
- * @param {ExecuteContext} context
- * @returns {boolean}
- */
-function referencesRowScope(expression, context) {
-  /** @type {IdentifierNode[]} */
-  const identifiers = []
-  collectColumnsFromExpr(expression, identifiers)
-  return identifiers.some(function isScopedReference(identifier) {
-    return Boolean(identifier.prefix && (
-      context.scope?.includes(identifier.prefix) || context.outerAliases?.has(identifier.prefix)
-    ))
-  })
 }
 
 /**

--- a/src/expression/batch.js
+++ b/src/expression/batch.js
@@ -1,4 +1,4 @@
-import { composeSelections, readBatchColumn, selectVector, selectedRowCount, valueAt } from '../backend/batch.js'
+import { composeSelections, isPromiseLike, readBatchColumn, resolveColumnResults, selectVector, selectedRowCount, valueAt } from '../backend/batch.js'
 import { isPlainObject, sqlEquals } from '../execute/utils.js'
 import { yieldToEventLoop } from '../execute/yield.js'
 import { isStringFunc } from '../validation/functions.js'
@@ -126,8 +126,8 @@ function compileKernelEvaluator(node, columns) {
       const results = dependencies.map(function readDependency(columnIndex) {
         return readBatchColumn({ batch, columnIndex, selection, signal })
       })
-      const vectors = resolveVectors(results)
-      if (vectors instanceof Promise) {
+      const vectors = resolveColumnResults(results)
+      if (isPromiseLike(vectors)) {
         return vectors.then(function evaluateResolved(resolved) {
           signal?.throwIfAborted()
           return evaluateKernel(kernel, resolved, selection, signal, rowOffset, rowOrdinals)
@@ -639,21 +639,4 @@ function readsIdentifier(node) {
   if (node.type === 'cast') return readsIdentifier(node.expr)
   if (node.type === 'function') return node.args.some(readsIdentifier)
   return false
-}
-
-/**
- * @param {ColumnResult[]} results
- * @returns {ColumnVector[] | Promise<ColumnVector[]>}
- */
-function resolveVectors(results) {
-  if (results.some(function isPromise(result) { return result instanceof Promise })) {
-    return Promise.all(results)
-  }
-  /** @type {ColumnVector[]} */
-  const vectors = []
-  for (const result of results) {
-    if (result instanceof Promise) throw new Error('Unexpected asynchronous column result')
-    vectors.push(result)
-  }
-  return vectors
 }

--- a/test/backend/batchAdapters.test.js
+++ b/test/backend/batchAdapters.test.js
@@ -37,6 +37,44 @@ describe('batch adapters', () => {
     ])
   })
 
+  it('resolves cells concurrently within a bounded batch', async () => {
+    /** @type {string[]} */
+    const started = []
+    /** @type {(() => void)[]} */
+    const releases = []
+    /** @type {AsyncRow[]} */
+    const rows = [
+      {
+        columns: schema,
+        cells: {
+          id: deferredCell('first id', 1, started, releases),
+          name: deferredCell('first name', 'a', started, releases),
+        },
+      },
+      {
+        columns: schema,
+        cells: {
+          id: deferredCell('second id', 2, started, releases),
+          name: deferredCell('second name', 'b', started, releases),
+        },
+      },
+    ]
+    const iterator = rowsToBatches(asyncValues(rows), schema, { batchRows: 2 })[Symbol.asyncIterator]()
+
+    const pending = iterator.next()
+    await new Promise(function waitForReads(resolve) { setTimeout(resolve, 0) })
+    const startedBeforeRelease = [...started]
+    for (const release of releases) release()
+    await pending
+
+    expect(startedBeforeRelease).toEqual([
+      'first id',
+      'first name',
+      'second id',
+      'second name',
+    ])
+  })
+
   it('keeps deferred columns lazy through the row adapter', async () => {
     /** @type {ReadColumn} */
     function readColumn() {
@@ -172,6 +210,24 @@ function resolvedRow(values) {
       return [name, function readCell() { return Promise.resolve(value) }]
     })),
     resolved: values,
+  }
+}
+
+/**
+ * @param {string} label
+ * @param {import('../../src/types.js').SqlPrimitive} value
+ * @param {string[]} started
+ * @param {(() => void)[]} releases
+ * @returns {() => Promise<import('../../src/types.js').SqlPrimitive>}
+ */
+function deferredCell(label, value, started, releases) {
+  /** @type {(value: import('../../src/types.js').SqlPrimitive) => void} */
+  let resolve
+  const promise = new Promise(function pendingCell(done) { resolve = done })
+  releases.push(function releaseCell() { resolve(value) })
+  return function readCell() {
+    started.push(label)
+    return promise
   }
 }
 

--- a/test/execute/batchAggregate.test.js
+++ b/test/execute/batchAggregate.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { runInNewContext } from 'node:vm'
 import { collect, executeSql } from '../../src/index.js'
 
 /**
@@ -92,6 +93,41 @@ describe('batch aggregate execution', () => {
         FROM data`,
     }))).resolves.toEqual([{ middle_total: 5, without_two: 8 }])
     expect(source.scan).not.toHaveBeenCalled()
+  })
+
+  it('accepts asynchronous column results from another realm', async () => {
+    const source = preparedSource({
+      fields: [{ id: 1, name: 'id', dataType: { type: 'number' }, nullable: false }],
+    }, {
+      id: [1, 2],
+    }, true)
+
+    await expect(collect(executeSql({
+      tables: { data: source },
+      query: 'SELECT SUM(id) AS total FROM data',
+    }))).resolves.toEqual([{ total: 3 }])
+  })
+
+  it('keeps unambiguous qualified aggregate inputs on the native batch path', async () => {
+    const id = 8675309
+    const source = preparedSource({
+      fields: [{ id: 1, name: 'id', dataType: { type: 'number' }, nullable: false }],
+    }, {
+      id: [id],
+    })
+    const resolve = vi.spyOn(Promise, 'resolve')
+
+    try {
+      await expect(collect(executeSql({
+        tables: { data: source },
+        query: 'SELECT SUM(d.id) AS total FROM data d',
+      }))).resolves.toEqual([{ total: id }])
+      expect(resolve.mock.calls.some(function resolvedSourceValue([value]) {
+        return value === id
+      })).toBe(false)
+    } finally {
+      resolve.mockRestore()
+    }
   })
 
   it('preserves struct-field precedence over a bare column', async () => {
@@ -189,9 +225,10 @@ function columnSource(values) {
 /**
  * @param {RelationSchema} sourceSchema
  * @param {Record<string, import('../../src/types.js').SqlPrimitive[]>} values
+ * @param {boolean} [foreignPromise]
  * @returns {AsyncDataSource}
  */
-function preparedSource(sourceSchema, values) {
+function preparedSource(sourceSchema, values, foreignPromise) {
   const length = Object.values(values)[0]?.length ?? 0
   return {
     schema: sourceSchema,
@@ -211,7 +248,14 @@ function preparedSource(sourceSchema, values) {
           yield {
             selection: { type: 'all', length },
             columns: fields.map(function loadedField(field) {
-              return { type: 'values', values: values[field.name], length }
+              /** @type {import('../../src/types.js').ColumnVector} */
+              const vector = { type: 'values', values: values[field.name], length }
+              if (!foreignPromise) return vector
+              return {
+                read() {
+                  return runInNewContext('Promise.resolve(vector)', { vector })
+                },
+              }
             }),
           }
         },


### PR DESCRIPTION
## Summary

- recognize promises and cross-realm thenables through one shared helper while preserving the synchronous column fast path
- resolve row cells concurrently within each bounded row-to-batch buffer
- share row-scope detection and keep unambiguous qualified aggregate inputs on the native batch path
- cover bounded concurrent materialization, foreign-realm promises, and qualified aggregates with regression tests

## Benchmarks

Compared this branch with `origin/master` on Node v26.5.1. Each engine received one warm-up, followed by five alternating measured runs with explicit garbage collection. The table reports medians; every operation also checked its output for correctness.

| Scenario | `origin/master` | This branch | Speedup |
| --- | ---: | ---: | ---: |
| Deferred row cells: 128 rows × 4 columns, 1 ms cell latency, 64-row batches | 599.37 ms | 2.99 ms | 200.43× |
| `SELECT SUM(d.id)` over 500,000 typed numeric values | 198.98 ms | 23.44 ms | 8.49× |

The deferred-cell case measures the bounded concurrency introduced by the row adapter; the aggregate case measures avoiding the row fallback for an unambiguous qualified identifier.

## Validation

- `npm test` — 65 files, 1,982 tests passed
- `npm run lint`
- `npx tsc`
