### PR TITLE
LIKE stringifies object operands like CAST VARCHAR

### DIFF
--- a/src/expression/binary.js
+++ b/src/expression/binary.js
@@ -1,3 +1,5 @@
+import { stringify } from '../execute/utils.js'
+
 /**
  * @import { BinaryOp, SqlPrimitive } from '../types.js'
  */
@@ -68,7 +70,11 @@ export function applyBinaryOp(op, a, b) {
   if (op === '>=') return a >= b
 
   if (op === 'LIKE') {
-    const str = String(a)
+    // Objects, arrays, and Dates stringify as JSON, the same coercion as
+    // CAST(x AS VARCHAR), so `x LIKE p` and `CAST(x AS VARCHAR) LIKE p` agree.
+    // String() would collapse every object to '[object Object]', making LIKE
+    // a silent never-match on JSON-typed columns.
+    const str = typeof a === 'object' ? stringify(a) : String(a)
     const pattern = String(b)
     const regexPattern = pattern
       .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/test/execute/execute.where.test.js
+++ b/test/execute/execute.where.test.js
@@ -211,6 +211,53 @@ describe('WHERE clause', () => {
     expect(result.map(r => r.name).sort()).toEqual(['Bob', 'Diana', 'Eve'])
   })
 
+  it('should filter with LIKE over an object column by its JSON text', async () => {
+    const calls = [
+      { id: 1, args: { command: 'cargo build' } },
+      { id: 2, args: { command: 'pnpm test' } },
+    ]
+    const result = await collect(executeSql({ tables: { calls }, query: 'SELECT id FROM calls WHERE args LIKE \'%cargo%\'' }))
+    expect(result.map(r => r.id)).toEqual([1])
+  })
+
+  it('should not match object columns against [object Object]', async () => {
+    const calls = [
+      { id: 1, args: { command: 'cargo build' } },
+      { id: 2, args: { command: 'pnpm test' } },
+    ]
+    const result = await collect(executeSql({ tables: { calls }, query: 'SELECT id FROM calls WHERE args LIKE \'%object Object%\'' }))
+    expect(result).toHaveLength(0)
+  })
+
+  it('should make LIKE on an object column agree with CAST AS VARCHAR', async () => {
+    const calls = [
+      { id: 1, args: { command: 'cargo build' } },
+      { id: 2, args: { command: 'pnpm test' } },
+    ]
+    const bare = await collect(executeSql({ tables: { calls }, query: 'SELECT id FROM calls WHERE args LIKE \'%"pnpm test"%\'' }))
+    const cast = await collect(executeSql({ tables: { calls }, query: 'SELECT id FROM calls WHERE CAST(args AS VARCHAR) LIKE \'%"pnpm test"%\'' }))
+    expect(bare.map(r => r.id)).toEqual([2])
+    expect(cast.map(r => r.id)).toEqual(bare.map(r => r.id))
+  })
+
+  it('should filter with LIKE over an array column by its JSON text', async () => {
+    const calls = [
+      { id: 1, tags: ['cargo', 'rust'] },
+      { id: 2, tags: ['pnpm'] },
+    ]
+    const result = await collect(executeSql({ tables: { calls }, query: 'SELECT id FROM calls WHERE tags LIKE \'%"rust"%\'' }))
+    expect(result.map(r => r.id)).toEqual([1])
+  })
+
+  it('should filter with LIKE over a Date column by its JSON text', async () => {
+    const events = [
+      { id: 1, at: new Date('2026-08-24T15:01:00Z') },
+      { id: 2, at: new Date('2026-07-21T15:01:00Z') },
+    ]
+    const result = await collect(executeSql({ tables: { events }, query: 'SELECT id FROM events WHERE at LIKE \'%2026-08-%\'' }))
+    expect(result.map(r => r.id)).toEqual([1])
+  })
+
   it('should filter with IN value list', async () => {
     const result = await collect(executeSql({ tables: { users }, query: 'SELECT * FROM users WHERE name IN (\'Alice\', \'Charlie\', \'Eve\')' }))
     expect(result).toHaveLength(3)


### PR DESCRIPTION
## Problem

`LIKE` coerces its value operand with `String()` (`src/expression/binary.js`). For any object-valued cell that produces the literal text `[object Object]`, so:

- `payload LIKE '%cargo%'` over `{ command: 'cargo build' }` silently matches **nothing**
- `payload LIKE '%object Object%'` matches **every** object row
- arrays match through their comma-joined form (`String(['cargo','rust'])` is `cargo,rust`), which appears to work but matches across element boundaries and collapses arrays of objects to `[object Object]` again

No error, no warning, just wrong rows. This has been the behavior since LIKE was introduced (5dd47db, Nov 2025); it surfaces now because JSON-typed columns are common in real datasets (found via hypaware's `ai_gateway_messages.tool_args`, where `tool_args LIKE '%cargo%'` returned 0 rows against 2,582 actual matches).

Same silent-no-match class as #39 (LIKE never matches strings containing newlines).

## Fix

Reuse the coercion `CAST(x AS VARCHAR)` already applies (`applyCast` in `src/expression/scalar.js`): objects go through `stringify()`, primitives through `String()`. One line, and it buys an invariant: **`x LIKE p` and `CAST(x AS VARCHAR) LIKE p` can never disagree.**

## Behavior changes

- Object columns: never-match → match against their JSON text (the fix)
- Array columns: matched `cargo,rust` → match `["cargo","rust"]`; patterns spanning the old comma joint would break, but no test in the suite relied on it
- Date columns: matched the locale string (`Sun Aug 24 2026 …`) → match the JSON ISO form (`"2026-08-24T15:01:00.000Z"`), consistent with CAST; the ISO form is also the one a date pattern like `'%2026-08-%'` can actually use

## Tests

Five new cases in `execute.where.test.js`: object matches by JSON text, `[object Object]` no longer matches, bare LIKE agrees with CAST AS VARCHAR, array matches by JSON text, Date matches by ISO text. Full suite: 65 files, 1,989 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)