### PR TITLE
REGEXP_LIKE stringifies object operands like LIKE and CAST VARCHAR

### DIFF
--- a/src/expression/regexp.js
+++ b/src/expression/regexp.js
@@ -1,3 +1,4 @@
+import { stringify } from '../execute/utils.js'
 import { ArgValueError } from '../validation/executionErrors.js'
 
 /**
@@ -187,5 +188,9 @@ export function evaluateRegexpLike({ node, args, rowIndex, cache }) {
       cache.regex = regex
     }
   }
-  return regex.test(String(string))
+  // Objects, arrays, and Dates test against their JSON text, the same
+  // coercion LIKE and CAST(x AS VARCHAR) use, so the three agree on
+  // JSON-typed columns. String() would collapse every object to
+  // '[object Object]', making REGEXP_LIKE a silent never-match on them.
+  return regex.test(typeof string === 'object' ? stringify(string) : String(string))
 }

--- a/test/execute/execute.regex.test.js
+++ b/test/execute/execute.regex.test.js
@@ -340,6 +340,58 @@ describe('regex functions', () => {
       }))
       expect(result).toEqual([{ id: 1 }, { id: 3 }])
     })
+
+    it('should match an object column by its JSON text', async () => {
+      const calls = [
+        { id: 1, args: { command: 'cargo build' } },
+        { id: 2, args: { command: 'pnpm test' } },
+      ]
+      const result = await collect(executeSql({
+        tables: { calls },
+        query: 'SELECT id FROM calls WHERE REGEXP_LIKE(args, \'cargo\')',
+      }))
+      expect(result.map(r => r.id)).toEqual([1])
+    })
+
+    it('should not match object columns against [object Object]', async () => {
+      const calls = [
+        { id: 1, args: { command: 'cargo build' } },
+      ]
+      const result = await collect(executeSql({
+        tables: { calls },
+        query: 'SELECT id FROM calls WHERE REGEXP_LIKE(args, \'object Object\')',
+      }))
+      expect(result).toHaveLength(0)
+    })
+
+    it('should make REGEXP_LIKE on an object column agree with CAST AS VARCHAR', async () => {
+      const calls = [
+        { id: 1, args: { command: 'cargo build' } },
+        { id: 2, args: { command: 'pnpm test' } },
+      ]
+      const bare = await collect(executeSql({
+        tables: { calls },
+        query: 'SELECT id FROM calls WHERE REGEXP_LIKE(args, \'"pnpm test"\')',
+      }))
+      const cast = await collect(executeSql({
+        tables: { calls },
+        query: 'SELECT id FROM calls WHERE REGEXP_LIKE(CAST(args AS VARCHAR), \'"pnpm test"\')',
+      }))
+      expect(bare.map(r => r.id)).toEqual([2])
+      expect(cast.map(r => r.id)).toEqual(bare.map(r => r.id))
+    })
+
+    it('should match an array column by its JSON text', async () => {
+      const calls = [
+        { id: 1, tags: ['cargo', 'rust'] },
+        { id: 2, tags: ['pnpm'] },
+      ]
+      const result = await collect(executeSql({
+        tables: { calls },
+        query: 'SELECT id FROM calls WHERE REGEXP_LIKE(tags, \'"rust"\')',
+      }))
+      expect(result.map(r => r.id)).toEqual([1])
+    })
   })
 
   describe('REGEXP_REPLACE', () => {


### PR DESCRIPTION
Completes #56 for the regexp family's boolean matchers.

`REGEXP_LIKE` coerced its string operand with `String()`, so an object operand became `'[object Object]'`: over a JSON-typed column it silently matched nothing (or everything, for patterns containing `object Object`), with no error to tell the caller the comparison was meaningless. #56 fixed exactly this for `LIKE`; this PR applies the same `stringify()` coercion to `evaluateRegexpLike`, which `REGEXP_MATCHES` and the batch kernels also route through, so `REGEXP_LIKE(x, p)` and `REGEXP_LIKE(CAST(x AS VARCHAR), p)` agree on every operand type.

Found via production agent-authored SQL against an AI-gateway message table, where JSON-typed columns (tool definitions, attributes) are routine filter targets and a silent never-match reads as a confident zero (hyparam/hypaware-server#397).

Tests mirror #56's: object column matches by JSON text, `[object Object]` never matches, agreement with the explicit CAST form, array column by JSON text. Suite green (1993 tests), lint clean.

Note for the reviewer: independent of #58 (regexp memoization); whichever merges second has a trivial rebase in `regexp.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)