### PR TITLE
Dedup-first eager aggregation for GROUP BY over string functions of one column

### DIFF
--- a/src/plan/eagerAggregate.js
+++ b/src/plan/eagerAggregate.js
@@ -1,0 +1,248 @@
+import { derivedAlias } from '../expression/alias.js'
+import { findAggregate } from '../validation/aggregates.js'
+
+/**
+ * @import { DerivedColumn, ExprNode, FunctionNode, IdentifierNode, OrderByItem } from '../types.js'
+ * @import { HashAggregateNode, QueryPlan } from './types.js'
+ */
+
+/**
+ * Eager aggregation: rewrite `GROUP BY f(col)` into a two-stage aggregate
+ * that deduplicates on the raw column first and applies `f` only to the
+ * distinct survivors.
+ *
+ *   HashAggregate(groupBy: [f(col)], columns: [key, COUNT(*)], child)
+ * becomes
+ *   HashAggregate(groupBy: [f(col)], columns: [key, SUM(partial)],
+ *     child: HashAggregate(groupBy: [col], columns: [col, COUNT(*) AS partial], child))
+ *
+ * Why: a string-producing function over a dictionary-encoded column
+ * manufactures a fresh full-length copy per input row, so grouping directly
+ * on `f(col)` scales its allocations with row count even when the column
+ * holds few distinct values. Grouping on the raw column first costs only
+ * reference comparisons, and `f` then runs once per distinct value. The
+ * chunked key evaluation cannot bound this on its own: it sizes chunks from
+ * the evaluated key bytes, and a wrapper like `substr(f(col), 1, 150)` makes
+ * the keys look tiny while every row still materializes the full-length
+ * intermediate inside the expression.
+ *
+ * The rewrite fires only when it is provably answer-preserving and aimed at
+ * the hazard:
+ * - a single GROUP BY key, built from deterministic scalar constructs over
+ *   exactly one unqualified column, containing at least one string-producing
+ *   function or cast to a string type (the per-row-copy hazard);
+ * - every output is either the key expression itself or a splittable
+ *   aggregate (COUNT/COUNTIF/SUM/MIN/MAX, no DISTINCT, no FILTER);
+ * - no HAVING, and any aggregate-level ORDER BY refers to output aliases
+ *   only, so it can move to the merge stage unchanged.
+ * Anything else returns the node untouched.
+ *
+ * @param {HashAggregateNode} node
+ * @returns {QueryPlan}
+ */
+export function rewriteEagerAggregate(node) {
+  if (node.groupBy.length !== 1 || node.having) return node
+  const key = node.groupBy[0]
+  const keyShape = analyzeKey(key)
+  if (!keyShape) return node
+
+  /** @type {OrderByItem[] | undefined} */
+  let mergedOrderBy
+  if (node.orderBy) {
+    mergedOrderBy = mergeStageOrderBy(node.orderBy, node.columns)
+    if (!mergedOrderBy) return node
+  }
+
+  const keySig = exprSig(key)
+  const columnName = keyShape.column
+  const at = { positionStart: key.positionStart, positionEnd: key.positionEnd }
+  /** @type {IdentifierNode} */
+  const rawColumn = { type: 'identifier', name: columnName, ...at }
+
+  /** @type {DerivedColumn[]} */
+  const innerColumns = [{ type: 'derived', expr: rawColumn, alias: columnName, ...at }]
+  /** @type {DerivedColumn[]} */
+  const outerColumns = []
+  for (const col of node.columns) {
+    if (col.type === 'star') return node
+    if (exprSig(col.expr) === keySig) {
+      outerColumns.push(col)
+      continue
+    }
+    if (col.expr.type !== 'function' || !isSplittableAggregate(col.expr)) return node
+    const partial = `__eager_agg_${innerColumns.length - 1}`
+    innerColumns.push({ type: 'derived', expr: col.expr, alias: partial, ...at })
+    const funcName = col.expr.funcName.toUpperCase()
+    // COUNT partials merge by summation; SUM/MIN/MAX merge with themselves.
+    const merge = funcName === 'COUNT' || funcName === 'COUNTIF' ? 'SUM' : funcName
+    outerColumns.push({
+      type: 'derived',
+      expr: { type: 'function', funcName: merge, args: [{ type: 'identifier', name: partial, ...at }], ...at },
+      alias: col.alias ?? derivedAlias(col.expr),
+      ...at,
+    })
+  }
+
+  /** @type {HashAggregateNode} */
+  const inner = {
+    type: 'HashAggregate',
+    groupBy: [rawColumn],
+    columns: innerColumns,
+    child: node.child,
+  }
+  /** @type {HashAggregateNode} */
+  const outer = {
+    type: 'HashAggregate',
+    groupBy: node.groupBy,
+    columns: outerColumns,
+    child: inner,
+  }
+  if (mergedOrderBy) outer.orderBy = mergedOrderBy
+  return outer
+}
+
+/** String-producing scalar functions: each output row is a fresh allocation. */
+const STRING_FUNCS = new Set([
+  'CONCAT', 'UPPER', 'LOWER', 'SUBSTRING', 'SUBSTR', 'TRIM', 'REPLACE',
+  'LEFT', 'RIGHT', 'SPLIT_PART', 'REGEXP_REPLACE', 'REGEXP_SUBSTR', 'REGEXP_EXTRACT',
+])
+
+const STRING_CAST_TYPES = new Set(['TEXT', 'STRING', 'VARCHAR'])
+
+/** Aggregates whose per-group partials merge losslessly across groups. */
+const SPLITTABLE_AGGREGATES = new Set(['COUNT', 'COUNTIF', 'SUM', 'MIN', 'MAX'])
+
+/**
+ * Validates a GROUP BY key for the eager rewrite: deterministic scalar
+ * constructs only, exactly one unqualified column, and at least one
+ * string-producing function or string cast (the reason to bother). Returns
+ * the column name, or undefined when the key does not qualify.
+ *
+ * @param {ExprNode} key
+ * @returns {{ column: string } | undefined}
+ */
+function analyzeKey(key) {
+  if (key.type === 'identifier') return undefined
+  /** @type {Set<string>} */
+  const columns = new Set()
+  let expanding = false
+
+  /**
+   * @param {ExprNode} node
+   * @returns {boolean}
+   */
+  function walk(node) {
+    switch (node.type) {
+    case 'literal':
+    case 'interval':
+      return true
+    case 'identifier':
+      if (node.prefix) return false
+      columns.add(node.name)
+      return true
+    case 'function': {
+      if (node.distinct || node.filter) return false
+      if (!STRING_FUNCS.has(node.funcName.toUpperCase())) return false
+      expanding = true
+      return node.args.every(walk)
+    }
+    case 'cast':
+      if (STRING_CAST_TYPES.has(node.toType)) expanding = true
+      return walk(node.expr)
+    case 'binary':
+      return walk(node.left) && walk(node.right)
+    case 'unary':
+      return walk(node.argument)
+    default:
+      return false
+    }
+  }
+
+  if (!walk(key) || !expanding || columns.size !== 1) return undefined
+  const [column] = columns
+  return { column }
+}
+
+/**
+ * Is this select expression a bare aggregate whose partials merge exactly?
+ * The aggregate's arguments are evaluated unchanged by the dedup stage, so
+ * they may be any scalar expression; only nested aggregates, windows, and
+ * subquery forms are rejected.
+ *
+ * @param {ExprNode} expr
+ * @returns {boolean}
+ */
+function isSplittableAggregate(expr) {
+  if (expr.type !== 'function' || expr.distinct || expr.filter) return false
+  if (!SPLITTABLE_AGGREGATES.has(expr.funcName.toUpperCase())) return false
+  return expr.args.every(arg => arg.type === 'star' || argIsScalar(arg))
+}
+
+/**
+ * @param {ExprNode} node
+ * @returns {boolean}
+ */
+function argIsScalar(node) {
+  if (node.type === 'window' || node.type === 'subquery' ||
+    node.type === 'exists' || node.type === 'not exists' ||
+    node.type === 'in' || node.type === 'star') return false
+  if (findAggregate(node)) return false
+  return true
+}
+
+/**
+ * Maps an aggregate-level ORDER BY onto the merge stage. A term evaluated
+ * there would see merge-stage groups (one row per distinct raw value), so an
+ * aggregate expression like `COUNT(*)` must not be re-evaluated: each term is
+ * redirected to the output alias of the select column it structurally
+ * matches, where the correctly merged value already lives. Alias resolution
+ * has already run, so `ORDER BY n` and `ORDER BY COUNT(*)` arrive as the
+ * same expression. Returns undefined when a term matches no output column.
+ *
+ * @param {OrderByItem[]} orderBy
+ * @param {HashAggregateNode['columns']} columns
+ * @returns {OrderByItem[] | undefined}
+ */
+function mergeStageOrderBy(orderBy, columns) {
+  /** @type {Map<string, string>} */
+  const aliasBySig = new Map()
+  /** @type {Set<string>} */
+  const aliases = new Set()
+  for (const col of columns) {
+    if (col.type === 'star') continue
+    const alias = col.alias ?? derivedAlias(col.expr)
+    aliases.add(alias)
+    aliasBySig.set(exprSig(col.expr), alias)
+  }
+  /** @type {OrderByItem[]} */
+  const terms = []
+  for (const term of orderBy) {
+    if (term.expr.type === 'identifier' && !term.expr.prefix && aliases.has(term.expr.name)) {
+      terms.push(term)
+      continue
+    }
+    const alias = aliasBySig.get(exprSig(term.expr))
+    if (alias === undefined) return undefined
+    terms.push({
+      ...term,
+      expr: { type: 'identifier', name: alias, positionStart: term.expr.positionStart, positionEnd: term.expr.positionEnd },
+    })
+  }
+  return terms
+}
+
+/**
+ * Structural signature of an expression, ignoring source positions. Twin of
+ * the private helper in execute/streamingAggregate.js; both must treat
+ * repeated SELECT and GROUP BY expressions as equal.
+ *
+ * @param {ExprNode} node
+ * @returns {string}
+ */
+function exprSig(node) {
+  return JSON.stringify(node, (key, value) => {
+    if (key === 'positionStart' || key === 'positionEnd') return undefined
+    if (typeof value === 'bigint') return { bigint: value.toString() }
+    return value
+  })
+}

--- a/src/plan/plan.js
+++ b/src/plan/plan.js
@@ -5,10 +5,11 @@ import { ParseError } from '../validation/parseErrors.js'
 import { ColumnNotFoundError, TableNotFoundError } from '../validation/tables.js'
 import { validateNoIdentifiers, validateScan, validateTableRefs } from '../validation/tables.js'
 import { collectColumnsFromExpr, collectScopeColumns, extractColumns, fromAlias, inferSelectSourceColumns, inferStatementColumns, statementScope, tableFunctionColumnNames } from './columns.js'
+import { rewriteEagerAggregate } from './eagerAggregate.js'
 
 /**
  * @import { AsyncDataSource, DerivedColumn, ExprNode, FromFunction, IdentifierNode, JoinClause, OrderByItem, PlanSqlOptions, ScanOptions, SelectColumn, SelectStatement, SetOperationStatement, Statement, WindowFunctionNode } from '../types.js'
- * @import { HashJoinNode, QueryPlan, TableFunctionNode, WindowSpec } from './types.js'
+ * @import { HashAggregateNode, HashJoinNode, QueryPlan, TableFunctionNode, WindowSpec } from './types.js'
  */
 
 /**
@@ -260,7 +261,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
       const groupBy = aliases.size > 0
         ? select.groupBy.map(expr => resolveAliases(expr, aliases))
         : select.groupBy
-      /** @type {QueryPlan} */
+      /** @type {HashAggregateNode} */
       const aggregatePlan = {
         type: 'HashAggregate',
         groupBy,
@@ -269,7 +270,7 @@ function planSelect({ select, ctePlans, cteColumns, tables, parentColumns, outer
         child: plan,
       }
       if (orderBy.length) aggregatePlan.orderBy = orderBy
-      plan = aggregatePlan
+      plan = rewriteEagerAggregate(aggregatePlan)
     } else if (!select.having && !select.where && plan.type === 'Scan' && isOwnScan && isAllCountStar(select.columns)) {
       plan = { type: 'Count', table: plan.table, columns: select.columns }
     } else {

--- a/test/plan/plan.eagerAggregate.test.js
+++ b/test/plan/plan.eagerAggregate.test.js
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { collect, executeSql } from '../../src/index.js'
+import { planSql } from '../../src/plan/plan.js'
+
+/**
+ * @import { HashAggregateNode, QueryPlan } from '../../src/plan/types.js'
+ */
+
+/**
+ * Asserts the plan is a two-stage (eager) aggregate and returns both stages.
+ *
+ * @param {QueryPlan} plan
+ * @returns {{ outer: HashAggregateNode, inner: HashAggregateNode }}
+ */
+function expectEager(plan) {
+  if (plan.type !== 'HashAggregate') throw new Error(`expected HashAggregate, got ${plan.type}`)
+  const outer = plan
+  if (outer.child.type !== 'HashAggregate') throw new Error(`expected eager rewrite, got ${outer.child.type} child`)
+  const inner = outer.child
+  return { outer, inner }
+}
+
+/**
+ * Asserts the plan is a single-stage aggregate (the rewrite did not fire).
+ *
+ * @param {QueryPlan} plan
+ */
+function expectSingleStage(plan) {
+  if (plan.type !== 'HashAggregate') throw new Error(`expected HashAggregate, got ${plan.type}`)
+  expect(plan.child.type).not.toBe('HashAggregate')
+}
+
+describe('eager aggregation rewrite', () => {
+  describe('plan shape', () => {
+    it('rewrites GROUP BY over a wrapped string function into two stages', () => {
+      const plan = planSql({
+        query: 'SELECT substr(regexp_replace(text, \'\\s+\', \' \'), 1, 150) AS k, COUNT(*) AS n FROM t GROUP BY k',
+      })
+      const { outer, inner } = expectEager(plan)
+      expect(inner.groupBy).toMatchObject([{ type: 'identifier', name: 'text' }])
+      expect(inner.columns).toMatchObject([
+        { alias: 'text', expr: { type: 'identifier', name: 'text' } },
+        { alias: '__eager_agg_0', expr: { type: 'function', funcName: 'COUNT' } },
+      ])
+      expect(outer.groupBy).toMatchObject([{ type: 'function', funcName: 'substr' }])
+      expect(outer.columns).toMatchObject([
+        { alias: 'k' },
+        { alias: 'n', expr: { type: 'function', funcName: 'SUM', args: [{ type: 'identifier', name: '__eager_agg_0' }] } },
+      ])
+    })
+
+    it('rewrites a string cast of a column', () => {
+      const plan = planSql({
+        query: 'SELECT substr(CAST(payload AS VARCHAR), 1, 5) AS k, COUNT(*) AS n FROM t GROUP BY k',
+      })
+      const { inner } = expectEager(plan)
+      expect(inner.groupBy).toMatchObject([{ type: 'identifier', name: 'payload' }])
+    })
+
+    it('keeps an alias-only ORDER BY on the merge stage', () => {
+      const plan = planSql({
+        query: 'SELECT upper(text) AS k, COUNT(*) AS n FROM t GROUP BY k ORDER BY n DESC',
+      })
+      const { outer } = expectEager(plan)
+      expect(outer.orderBy).toMatchObject([{ expr: { type: 'identifier', name: 'n' }, direction: 'DESC' }])
+    })
+
+    it('does not rewrite a bare column key', () => {
+      expectSingleStage(planSql({ query: 'SELECT text, COUNT(*) FROM t GROUP BY text' }))
+    })
+
+    it('does not rewrite a key without a string-producing construct', () => {
+      expectSingleStage(planSql({ query: 'SELECT id % 10 AS k, COUNT(*) FROM t GROUP BY k' }))
+    })
+
+    it('does not rewrite when the key references two columns', () => {
+      expectSingleStage(planSql({ query: 'SELECT upper(a || b) AS k, COUNT(*) FROM t GROUP BY k' }))
+    })
+
+    it('does not rewrite a qualified column', () => {
+      expectSingleStage(planSql({ query: 'SELECT upper(t.text) AS k, COUNT(*) FROM t GROUP BY k' }))
+    })
+
+    it('does not rewrite with HAVING', () => {
+      expectSingleStage(planSql({ query: 'SELECT upper(text) AS k, COUNT(*) AS n FROM t GROUP BY k HAVING COUNT(*) > 1' }))
+    })
+
+    it('does not rewrite unsplittable aggregates', () => {
+      expectSingleStage(planSql({ query: 'SELECT upper(text) AS k, AVG(n) FROM t GROUP BY k' }))
+      expectSingleStage(planSql({ query: 'SELECT upper(text) AS k, COUNT(DISTINCT id) FROM t GROUP BY k' }))
+    })
+
+    it('redirects ORDER BY over a selected aggregate to its output alias', () => {
+      const plan = planSql({ query: 'SELECT upper(text) AS k, COUNT(*) AS n FROM t GROUP BY k ORDER BY COUNT(*) DESC' })
+      const { outer } = expectEager(plan)
+      expect(outer.orderBy).toMatchObject([{ expr: { type: 'identifier', name: 'n' }, direction: 'DESC' }])
+    })
+
+    it('does not rewrite when ORDER BY needs an unselected aggregate', () => {
+      expectSingleStage(planSql({ query: 'SELECT upper(text) AS k, COUNT(*) AS n FROM t GROUP BY k ORDER BY SUM(id) DESC' }))
+    })
+
+    it('does not rewrite multi-key grouping', () => {
+      expectSingleStage(planSql({ query: 'SELECT upper(text) AS k, id, COUNT(*) FROM t GROUP BY k, id' }))
+    })
+  })
+
+  describe('execution equivalence', () => {
+    // Repeated raw values, distinct raw values that normalize to the same
+    // key, a NULL key, and NULLs under a counted column.
+    const messages = [
+      { id: 1, text: 'Hello  World', n: 10, v: 'x' },
+      { id: 2, text: 'Hello World', n: 5, v: null },
+      { id: 3, text: 'HELLO  WORLD', n: 2, v: 'y' },
+      { id: 4, text: null, n: 1, v: null },
+      { id: 5, text: 'Hello  World', n: 4, v: null },
+    ]
+
+    it('merges distinct raw values that normalize to one key', async () => {
+      const result = await collect(executeSql({
+        tables: { messages },
+        query: 'SELECT lower(regexp_replace(text, \'\\s+\', \' \')) AS k, COUNT(*) AS c, SUM(n) AS total FROM messages GROUP BY k ORDER BY c DESC',
+      }))
+      expect(result).toEqual([
+        { k: 'hello world', c: 4, total: 21 },
+        { k: null, c: 1, total: 1 },
+      ])
+    })
+
+    it('splits COUNT(column), MIN, and MAX correctly', async () => {
+      const result = await collect(executeSql({
+        tables: { messages },
+        query: 'SELECT lower(regexp_replace(text, \'\\s+\', \' \')) AS k, COUNT(v) AS cv, MIN(id) AS mn, MAX(id) AS mx FROM messages GROUP BY k ORDER BY cv DESC',
+      }))
+      expect(result).toEqual([
+        { k: 'hello world', cv: 2, mn: 1, mx: 5 },
+        { k: null, cv: 0, mn: 4, mx: 4 },
+      ])
+    })
+
+    it('produces the same rows through a CTE', async () => {
+      const result = await collect(executeSql({
+        tables: { messages },
+        query: 'WITH s AS (SELECT * FROM messages) SELECT upper(text) AS k, COUNT(*) AS c FROM s GROUP BY k ORDER BY c DESC',
+      }))
+      expect(result).toEqual([
+        { k: 'HELLO  WORLD', c: 3 },
+        { k: 'HELLO WORLD', c: 1 },
+        { k: null, c: 1 },
+      ])
+    })
+
+    it('matches the single-stage result on an unrewritten shape', async () => {
+      // HAVING blocks the rewrite; this pins the direct path as the oracle
+      // for the same grouping so the two tests above compare like for like.
+      const result = await collect(executeSql({
+        tables: { messages },
+        query: 'SELECT lower(regexp_replace(text, \'\\s+\', \' \')) AS k, COUNT(*) AS c, SUM(n) AS total FROM messages GROUP BY k HAVING COUNT(*) > 0 ORDER BY c DESC',
+      }))
+      expect(result).toEqual([
+        { k: 'hello world', c: 4, total: 21 },
+        { k: null, c: 1, total: 1 },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## The query that was breaking

hypaware-server's 2026-08-26 outage query (hyparam/hypaware-server#394 and #395 hold the containment side) still OOMs a 4GB heap on v0.16.3:

```sql
SELECT substr(regexp_replace(system_text, '\s+', ' '), 1, 150) AS k, COUNT(*) AS n
FROM ai_gateway_messages GROUP BY k ORDER BY n DESC
```

Data: 94,392 rows sharing 3,445 distinct ~90KB `system_text` values by reference (8.2GB logical, parquet dictionary decode).

The deciding characteristic is **a fat intermediate hidden behind a small final key**. #60 sizes chunks from the evaluated *key* bytes, and `substr(..., 1, 150)` makes every key look 150 bytes wide, so the chunk grows back to its 4000-row cap while each row still materializes a full ~90KB `regexp_replace` copy inside the expression, where the sizing never sees it. Any `GROUP BY substr(lower(col), ...)` or `GROUP BY substr(CAST(col AS VARCHAR), ...)` fails the same way. Unwrapped (`GROUP BY regexp_replace(...)`, #60's own bench shape) stays bounded, so the wrapper is what breaks it.

## The fix: dedup first, transform after

```
HashAggregate(groupBy: [f(col)], columns: [key, COUNT(*)], child)
  becomes
HashAggregate(groupBy: [f(col)], columns: [key, SUM(partial)],
  child: HashAggregate(groupBy: [col], columns: [col, COUNT(*) AS partial], child))
```

Grouping on the raw column only compares references, so the inner stage collapses 94k rows to 3,445 before `f` runs once per survivor. Answer-preserving because `f` is deterministic, and the executor is untouched: both stages are ordinary `HashAggregate` nodes, still covered by #60's chunking. This is the relational form of the "dictionary-aware batch evaluation" #60's notes name as a follow-up, and it covers the repeated-input case #57/#58 targeted without a result cache. New file `src/plan/eagerAggregate.js`, applied where `planSelect` builds the aggregate node.

## When it fires

All of: one GROUP BY key over **exactly one unqualified column** through deterministic scalar constructs; the key holds **at least one string-producing function or string cast**; every output is the key or a splittable aggregate (`COUNT`/`COUNTIF`/`SUM`/`MIN`/`MAX`, no `DISTINCT`/`FILTER`); no `HAVING`; and every aggregate-level ORDER BY term matches an output column, so it can be redirected to that alias (re-evaluating `COUNT(*)` on the merge stage would count partial rows). Otherwise the node is returned unchanged.

## Results

One process per shape, `executeSql` directly, 4GB cap, peak `heapUsed` sampled at 25ms (peaks are lower bounds; pass/fail is the reliable signal). Top two rows run 3x.

| Query | Deciding characteristic | v0.16.3 | This PR |
|---|---|---|---|
| `GROUP BY substr(regexp_replace(text,…),1,150)` | fat intermediate behind a small key; values repeat | **OOM**, 3/3 | **14.6 / 15.3 / 14.8s, 761MB**, 3/3 |
| `GROUP BY regexp_replace(text,…)` | fat value *is* the key; values repeat | 171s, 1.56GB | **10.4s**, 16x faster |
| `GROUP BY text`, `GROUP BY id % 10`, `JSON_EXTRACT(...)`, `LIKE` / `REGEXP_LIKE` | no string function over the key, or no aggregate at all | ok | unchanged, declines |
| `SELECT regexp_replace(text,…) FROM t` | no aggregate: the ~8.2GB result *is* the answer | OOM | OOM |
| `SELECT upper(text) AS k FROM t ORDER BY k` (no LIMIT) | a full sort retains every key by definition | OOM | OOM |
| wrapped key over **60k all-distinct** ~90KB values | nothing repeats, so there is no dedup to win | OOM | OOM |

Rows 4-5 need bounded sort-key evaluation and a caller-side refusal, not a plan rewrite (`ORDER BY ... LIMIT n` is already bounded by the existing top-k path). Row 6 is not a regression - v0.16.3 fails it too, since the sizing blindness is independent of cardinality - but the mechanism does shift from evaluation churn to dedup-map retention.

I built and measured a byte-capped flushing dedup map for row 6 and **rejected it**: on dictionary data it ran 136s against 14.8s, because 3,445 x 90KB is ~620MB of key bytes, far above any sane bound, so the map flushes nearly every chunk and the merge stage re-runs `f` on ~82k rows instead of 3,445. It still OOM'd on all-distinct data. A byte tally cannot tell a shared dictionary reference (~8 bytes of real cost) from a uniquely-held one (~180KB), so row 6 wants a cardinality signal from the data source rather than an executor heuristic.

## Tests

16 in `test/plan/plan.eagerAggregate.test.js`: rewrite shape (incident query, string casts, ORDER BY redirection), all nine decline conditions, and execution equivalence over repeated values, distinct values normalizing to one key, NULL keys, and NULL-skipping COUNT (COUNT/SUM/MIN/MAX, CTE, alias ORDER BY). Suite 2,009 green; `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7LMSa2odTyibuvg4AzdGg
